### PR TITLE
Implement smooth scroll snap navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 import { Layout } from './layout/Layout';
 import { ProgressBar } from './components/ui/ProgressBar';
 
-const Home = lazy(() => import('./pages/Home'));
-const Features = lazy(() => import('./pages/Features'));
-const Pricing = lazy(() => import('./pages/Pricing'));
-const Creators = lazy(() => import('./pages/Creators'));
+const Landing = lazy(() => import('./pages/Landing'));
 
 export function App() {
   return (
@@ -15,10 +12,7 @@ export function App() {
       <Layout>
         <Suspense fallback={<div className="p-8">Loading...</div>}>
           <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/features" element={<Features />} />
-            <Route path="/pricing" element={<Pricing />} />
-            <Route path="/creators" element={<Creators />} />
+            <Route path="/" element={<Landing />} />
           </Routes>
         </Suspense>
       </Layout>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -20,9 +20,7 @@ export default function Hero() {
 
   return (
       <section
-          id="hero"
           className="
-        min-h-screen
         flex flex-col md:flex-row
         items-center justify-between
         px-6 md:px-12     /* increase horizontal padding on md+ */

--- a/src/components/scroll/ScrollProvider.tsx
+++ b/src/components/scroll/ScrollProvider.tsx
@@ -1,0 +1,48 @@
+import { createContext, ReactNode, useContext, useEffect, useRef, useState } from 'react';
+
+interface Section {
+  id: string;
+  el: HTMLElement;
+}
+
+interface ScrollContextValue {
+  currentId: string;
+  sections: React.MutableRefObject<Section[]>;
+  setCurrentId: (id: string) => void;
+}
+
+const ScrollContext = createContext<ScrollContextValue | null>(null);
+
+export function useScrollContext() {
+  const ctx = useContext(ScrollContext);
+  if (!ctx) throw new Error('useScrollContext must be used within ScrollProvider');
+  return ctx;
+}
+
+export function ScrollProvider({ children }: { children: ReactNode }) {
+  const [currentId, setCurrentId] = useState('');
+  const sections = useRef<Section[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+            const id = (entry.target as HTMLElement).dataset.sectionId!;
+            setCurrentId(id);
+            if (window.location.hash !== `#${id}`) {
+              history.replaceState(null, '', `#${id}`);
+            }
+          }
+        });
+      },
+      { threshold: 0.5 }
+    );
+    sections.current.forEach((s) => observer.observe(s.el));
+    return () => observer.disconnect();
+  }, []);
+
+  const value = { currentId, sections, setCurrentId };
+  return <ScrollContext.Provider value={value}>{children}</ScrollContext.Provider>;
+}

--- a/src/components/scroll/Section.tsx
+++ b/src/components/scroll/Section.tsx
@@ -1,0 +1,33 @@
+import { HTMLAttributes, useEffect, useRef } from 'react';
+import { useScrollContext } from './ScrollProvider';
+import clsx from 'clsx';
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  id: string;
+  snap?: 'start' | 'center' | 'end';
+}
+
+export function Section({ id, snap = 'start', className, ...rest }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const { sections } = useScrollContext();
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    sections.current.push({ id, el });
+    el.dataset.sectionId = id;
+    return () => {
+      sections.current = sections.current.filter((s) => s.id !== id);
+    };
+  }, [id, sections]);
+
+  return (
+    <div
+      id={id}
+      ref={ref}
+      data-section-id={id}
+      className={clsx('min-h-screen', `snap-${snap}`, className)}
+      {...rest}
+    />
+  );
+}

--- a/src/components/scroll/SmoothLink.tsx
+++ b/src/components/scroll/SmoothLink.tsx
@@ -1,0 +1,34 @@
+import { AnchorHTMLAttributes } from 'react';
+import clsx from 'clsx';
+import { useScrollContext } from './ScrollProvider';
+import { smoothScroll } from './smoothScroll';
+
+interface Props extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  href: string; // expects #id
+  className?: string;
+}
+
+export function SmoothLink({ href, className, children, ...rest }: Props) {
+  const { sections, currentId } = useScrollContext();
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    const id = href.replace('#', '');
+    const el = sections.current.find((s) => s.id === id)?.el;
+    if (el) smoothScroll(el);
+  };
+
+  const active = currentId === href.replace('#', '');
+
+  return (
+    <a
+      href={href}
+      onClick={handleClick}
+      className={clsx(className, active && 'active')}
+      aria-current={active ? 'page' : undefined}
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/components/scroll/smoothScroll.ts
+++ b/src/components/scroll/smoothScroll.ts
@@ -1,0 +1,14 @@
+export async function smoothScroll(target: HTMLElement) {
+  const prefersReduced =
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const behavior = prefersReduced ? 'auto' : 'smooth';
+
+  if ('scrollBehavior' in document.documentElement.style) {
+    target.scrollIntoView({ behavior, block: 'start' });
+  } else {
+    const { polyfill } = await import('smoothscroll-polyfill');
+    polyfill();
+    target.scrollIntoView({ behavior, block: 'start' });
+  }
+}

--- a/src/components/scroll/useActiveSection.ts
+++ b/src/components/scroll/useActiveSection.ts
@@ -1,0 +1,6 @@
+import { useScrollContext } from './ScrollProvider';
+
+export function useActiveSection() {
+  const { currentId } = useScrollContext();
+  return currentId;
+}

--- a/src/components/scroll/useScrollSnap.ts
+++ b/src/components/scroll/useScrollSnap.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useScrollContext } from './ScrollProvider';
+import { smoothScroll } from './smoothScroll';
+
+export function useScrollSnap() {
+  const { currentId, sections } = useScrollContext();
+  const animating = useRef(false);
+  const touchStart = useRef(0);
+
+  const scrollToId = useCallback(
+    (id: string) => {
+      const el = sections.current.find((s) => s.id === id)?.el;
+      if (el) {
+        animating.current = true;
+        smoothScroll(el).then(() => {
+          setTimeout(() => {
+            animating.current = false;
+          }, 100);
+        });
+      }
+    },
+    [sections]
+  );
+
+  const handler = useCallback(
+    (dir: number) => {
+      if (animating.current) return;
+      const index = sections.current.findIndex((s) => s.id === currentId);
+      const next = sections.current[index + dir];
+      if (next) scrollToId(next.id);
+    },
+    [currentId, scrollToId, sections]
+  );
+
+  useEffect(() => {
+    const onWheel = (e: WheelEvent) => {
+      if (Math.abs(e.deltaY) < 50) return;
+      handler(e.deltaY > 0 ? 1 : -1);
+    };
+    const onTouchStart = (e: TouchEvent) => {
+      touchStart.current = e.touches[0].clientY;
+    };
+    const onTouchEnd = (e: TouchEvent) => {
+      const diff = touchStart.current - e.changedTouches[0].clientY;
+      if (Math.abs(diff) > 50) handler(diff > 0 ? 1 : -1);
+    };
+    window.addEventListener('wheel', onWheel, { passive: true });
+    window.addEventListener('touchstart', onTouchStart, { passive: true });
+    window.addEventListener('touchend', onTouchEnd, { passive: true });
+    return () => {
+      window.removeEventListener('wheel', onWheel);
+      window.removeEventListener('touchstart', onTouchStart);
+      window.removeEventListener('touchend', onTouchEnd);
+    };
+  }, [handler]);
+
+  return { scrollToId };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,16 @@ body {
   background-size: 4px 4px;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
+.snap-container {
+  scroll-snap-type: y mandatory;
+  scroll-padding-top: 5rem;
+  overscroll-behavior-y: none;
+}
+
 /*========================================================
   Navbar & Navigation Links
 ========================================================*/

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,13 +1,23 @@
 import WizardDrawer from "../components/WizardDrawer";
 import { ReactNode } from 'react';
 import { Navbar } from './Navbar';
+import { ScrollProvider } from '../components/scroll/ScrollProvider';
+import { useScrollSnap } from '../components/scroll/useScrollSnap';
+
+function SnapInit() {
+  useScrollSnap();
+  return null;
+}
 
 export function Layout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen flex flex-col">
-      <Navbar />
-      <WizardDrawer />
-      <main className="flex-1 pt-20 pb-8">{children}</main>
-    </div>
+    <ScrollProvider>
+      <SnapInit />
+      <div className="min-h-screen flex flex-col overflow-y-auto snap-container">
+        <Navbar />
+        <WizardDrawer />
+        <main className="flex-1 pt-20 pb-8">{children}</main>
+      </div>
+    </ScrollProvider>
   );
 }

--- a/src/layout/Navbar.tsx
+++ b/src/layout/Navbar.tsx
@@ -1,53 +1,29 @@
 import { useState } from 'react';
-import { Link, NavLink, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Button } from '../components/ui/Button';
 import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import { SmoothLink } from '../components/scroll/SmoothLink';
 
 export function Navbar() {
   const [open, setOpen] = useState(false);
-  const location = useLocation();
-
-  function handleNavClick(id: string) {
-    if (location.pathname === '/') {
-      document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
-    }
-    setOpen(false);
-  }
 
   return (
     <header className="fixed top-0 left-0 w-full bg-dark1/80 backdrop-blur-sm z-50 shadow-md">
       <div className="max-w-7xl mx-auto flex items-center justify-between px-6 h-20">
         <Link to="/" className="text-2xl font-bold text-white">GramCourses</Link>
         <nav className="hidden md:flex flex-1 justify-center space-x-6">
-          <NavLink
-            to="/"
-            onClick={() => handleNavClick('hero')}
-            className="nav-link"
-            aria-label="Home"
-          >
+          <SmoothLink href="#home" className="nav-link" aria-label="Home">
             Home
-          </NavLink>
-          <NavLink
-            to="/features"
-            className="nav-link"
-            aria-label="Features"
-          >
+          </SmoothLink>
+          <SmoothLink href="#features" className="nav-link" aria-label="Features">
             Features
-          </NavLink>
-          <NavLink
-            to="/pricing"
-            className="nav-link"
-            aria-label="Pricing"
-          >
+          </SmoothLink>
+          <SmoothLink href="#pricing" className="nav-link" aria-label="Pricing">
             Pricing
-          </NavLink>
-          <NavLink
-            to="/creators"
-            className="nav-link"
-            aria-label="Creators"
-          >
+          </SmoothLink>
+          <SmoothLink href="#creators" className="nav-link" aria-label="Creators">
             Creators
-          </NavLink>
+          </SmoothLink>
         </nav>
         <Button
           size="sm"
@@ -67,35 +43,18 @@ export function Navbar() {
       </div>
       {open && (
         <div className="md:hidden bg-dark2 px-6 pb-4 space-y-3">
-          <NavLink
-            to="/"
-            onClick={() => handleNavClick('hero')}
-            className="block nav-link"
-            aria-label="Home"
-          >
+          <SmoothLink href="#home" className="block nav-link" aria-label="Home" onClick={() => setOpen(false)}>
             Home
-          </NavLink>
-          <NavLink
-            to="/features"
-            className="block nav-link"
-            aria-label="Features"
-          >
+          </SmoothLink>
+          <SmoothLink href="#features" className="block nav-link" aria-label="Features" onClick={() => setOpen(false)}>
             Features
-          </NavLink>
-          <NavLink
-            to="/pricing"
-            className="block nav-link"
-            aria-label="Pricing"
-          >
+          </SmoothLink>
+          <SmoothLink href="#pricing" className="block nav-link" aria-label="Pricing" onClick={() => setOpen(false)}>
             Pricing
-          </NavLink>
-          <NavLink
-            to="/creators"
-            className="block nav-link"
-            aria-label="Creators"
-          >
+          </SmoothLink>
+          <SmoothLink href="#creators" className="block nav-link" aria-label="Creators" onClick={() => setOpen(false)}>
             Creators
-          </NavLink>
+          </SmoothLink>
           <Button
             size="sm"
             className="w-full"

--- a/src/pages/Creators.tsx
+++ b/src/pages/Creators.tsx
@@ -8,7 +8,7 @@ export default function Creators() {
   const [selected, setSelected] = useState<Creator | null>(null);
 
   return (
-    <div className="max-w-5xl mx-auto px-6" id="creators">
+    <div className="max-w-5xl mx-auto px-6">
       <h2 className="text-3xl font-bold text-white text-center mb-8">Success Stories</h2>
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 justify-items-center">
         {creators.map((c) => (

--- a/src/pages/Features.tsx
+++ b/src/pages/Features.tsx
@@ -3,7 +3,7 @@ import { Card } from '../components/ui/Card';
 
 export default function Features() {
   return (
-    <div className="max-w-7xl mx-auto px-6" id="features">
+    <div className="max-w-7xl mx-auto px-6">
       <h2 className="text-3xl font-bold text-white text-center mb-8">Speed → Revenue</h2>
       <div className="grid md:grid-cols-2 gap-6">
         {features.map((f) => (

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,0 +1,24 @@
+import Home from './Home';
+import Features from './Features';
+import Pricing from './Pricing';
+import Creators from './Creators';
+import { Section } from '../components/scroll/Section';
+
+export default function Landing() {
+  return (
+    <>
+      <Section id="home" className="bg-page-gradient">
+        <Home />
+      </Section>
+      <Section id="features" className="bg-dark2">
+        <Features />
+      </Section>
+      <Section id="pricing" className="bg-dark1">
+        <Pricing />
+      </Section>
+      <Section id="creators" className="bg-dark2">
+        <Creators />
+      </Section>
+    </>
+  );
+}

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -15,7 +15,7 @@ export default function Pricing() {
   }
 
   return (
-    <div className="max-w-5xl mx-auto px-6" id="pricing">
+    <div className="max-w-5xl mx-auto px-6">
       <h2 className="text-3xl font-bold text-white text-center mb-8">Pricing & Plans</h2>
       <div className="flex justify-center mb-6">
         <button


### PR DESCRIPTION
## Summary
- add scroll context provider and hooks for snap scrolling
- create section wrapper component
- replace nav links with smooth links
- assemble sections into a single landing page
- wire scroll snapping and provider in layout
- tweak global styles for scroll snap

## Testing
- `npm run build` *(fails: TS6306 references & missing tsconfig composite)*
- `npm test`
- `npm run lint`
- `npm run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6842364d3a008333ba730e4926894a71