### PR TITLE
Add AI wizard flow with Redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ npm test          # unit tests
 npm run lint      # lint codebase
 npm run test:e2e  # Cypress smoke tests
 ```
+
+## AI Wizard Flow
+
+Set the following environment variables before running the wizard:
+
+```bash
+VITE_OPENAI_API_URL=<your-ai-endpoint>
+VITE_STRIPE_PK=<your-stripe-publishable-key>
+```
+
+These keys power the pricing and marketing steps during the AI onboarding flow.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@headlessui/react": "^2.2.2",
         "@heroicons/react": "^2.2.0",
+        "@reduxjs/toolkit": "^2.3.0",
         "clsx": "^2.1.1",
         "framer-motion": "^12.8.0",
         "lottie-react": "^2.4.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^4.12.0",
+        "react-redux": "^9.1.2",
         "react-router-dom": "^6.30.1",
         "smoothscroll-polyfill": "^0.4.4"
       },
@@ -38,6 +40,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
         "postcss": "^8.5.3",
+        "prettier": "^3.2.5",
         "tailwindcss": "^3.4.3",
         "ts-jest": "^29.3.4",
         "typescript": "~5.7.2",
@@ -2521,6 +2524,32 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -2872,6 +2901,18 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -3414,7 +3455,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3456,6 +3497,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -4967,7 +5014,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cypress": {
@@ -6562,6 +6609,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -9846,6 +9903,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -10044,6 +10117,29 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -10123,6 +10219,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -10142,6 +10253,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "jest",
-    "test:e2e": "cypress run"
+    "test:e2e": "cypress run",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@headlessui/react": "^2.2.2",
@@ -21,7 +22,9 @@
     "react-dom": "^19.0.0",
     "react-icons": "^4.12.0",
     "react-router-dom": "^6.30.1",
-    "smoothscroll-polyfill": "^0.4.4"
+    "smoothscroll-polyfill": "^0.4.4",
+    "@reduxjs/toolkit": "^2.3.0",
+    "react-redux": "^9.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
@@ -47,6 +50,7 @@
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",
     "vite": "^6.3.1",
-    "vite-plugin-svgr": "^4.3.0"
+    "vite-plugin-svgr": "^4.3.0",
+    "prettier": "^3.2.5"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,25 @@
-import { Suspense, lazy } from 'react';
-import { Routes, Route } from 'react-router-dom';
-import { Layout } from './layout/Layout';
-import { ProgressBar } from './components/ui/ProgressBar';
+import { Suspense, lazy } from "react";
+import { Routes, Route } from "react-router-dom";
+import { Layout } from "./layout/Layout";
+import { ProgressBar } from "./components/ui/ProgressBar";
 
-const Landing = lazy(() => import('./pages/Landing'));
+const Landing = lazy(() => import("./pages/Landing"));
+const WizardLayout = lazy(() => import("./features/wizard/WizardLayout"));
+const AIDemoModal = lazy(() => import("./components/modals/AIDemoModal"));
 
 export function App() {
-    return (
-        <>
-            <ProgressBar />
-            <Layout>
-                <Suspense fallback={<div className="p-8">Loading...</div>}>
-                    <Routes>
-                        <Route path="/" element={<Landing />} />
-                    </Routes>
-                </Suspense>
-            </Layout>
-        </>
-    );
+  return (
+    <>
+      <ProgressBar />
+      <Layout>
+        <Suspense fallback={<div className="p-8">Loading...</div>}>
+          <Routes>
+            <Route path="/" element={<Landing />} />
+            <Route path="/wizard" element={<WizardLayout />} />
+            <Route path="/demo" element={<AIDemoModal />} />
+          </Routes>
+        </Suspense>
+      </Layout>
+    </>
+  );
 }

--- a/src/components/FieldGroup.tsx
+++ b/src/components/FieldGroup.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+
+interface Props {
+  label: string;
+  children: ReactNode;
+}
+
+export function FieldGroup({ label, children }: Props) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-sm font-medium text-gray-200">{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,27 +1,29 @@
 // src/components/Hero.tsx
-import { useEffect, useState } from 'react'
-import { Button } from './ui/Button'
-import { LiveCounter } from './LiveCounter'
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "./ui/Button";
+import { LiveCounter } from "./LiveCounter";
 
 export default function Hero() {
-  const [ticker, setTicker] = useState('@coachmike just earned $3,482')
+  const [ticker, setTicker] = useState("@coachmike just earned $3,482");
+  const navigate = useNavigate();
   useEffect(() => {
     const data = [
-      '@coachmike just earned $3,482',
-      '@creatorsara just earned $1,208',
-      '@buildtim just earned $542',
-    ]
-    let i = 0
+      "@coachmike just earned $3,482",
+      "@creatorsara just earned $1,208",
+      "@buildtim just earned $542",
+    ];
+    let i = 0;
     const id = setInterval(() => {
-      i = (i + 1) % data.length
-      setTicker(data[i])
-    }, 3000)
-    return () => clearInterval(id)
-  }, [])
+      i = (i + 1) % data.length;
+      setTicker(data[i]);
+    }, 3000);
+    return () => clearInterval(id);
+  }, []);
 
   return (
-      <section
-          className="
+    <section
+      className="
         relative overflow-hidden snap-container
         min-h-screen
         bg-transparent                         /* no solid bg—shows seamless-gradient */
@@ -30,19 +32,19 @@ export default function Hero() {
         px-6 md:px-12 lg:px-24
         pt-28 pb-16
       "
-      >
-        {/** 1) Very faint neon wash behind everything (–z-20) */}
-        <div
-            className="
+    >
+      {/** 1) Very faint neon wash behind everything (–z-20) */}
+      <div
+        className="
           absolute inset-0
           bg-gradient-to-br from-insta-purple/10 via-insta-blue/10 to-insta-pink/10
           -z-20
         "
-        />
+      />
 
-        {/** 2) Neon “orb” behind content (–z-10, no blur) */}
-        <div
-            className="
+      {/** 2) Neon “orb” behind content (–z-10, no blur) */}
+      <div
+        className="
           absolute top-[-10%] right-[-5%]
           w-96 h-96 rounded-full
           bg-gradient-to-tr from-insta-pink/30 via-insta-purple/25 to-insta-blue/20
@@ -50,11 +52,11 @@ export default function Hero() {
           opacity-80
           -z-10
         "
-        />
+      />
 
-        {/** 3) Small neon “spark” circles (–z-10, no blur) */}
-        <div
-            className="
+      {/** 3) Small neon “spark” circles (–z-10, no blur) */}
+      <div
+        className="
           absolute bottom-10 right-10
           w-24 h-24 rounded-full
           bg-gradient-to-br from-insta-orange/25 to-insta-yellow/20
@@ -62,9 +64,9 @@ export default function Hero() {
           opacity-70
           -z-10
         "
-        />
-        <div
-            className="
+      />
+      <div
+        className="
           absolute top-1/3 left-10
           w-20 h-20 rounded-full
           bg-gradient-to-br from-insta-purple/25 to-insta-pink/20
@@ -72,14 +74,14 @@ export default function Hero() {
           opacity-70
           -z-10
         "
-        />
+      />
 
-        {/** ──────────────────────────────────────────────────
+      {/** ──────────────────────────────────────────────────
          TEXT & BUTTONS (z-10)
          ─────────────────────────────────────────────────── */}
-        <div className="relative z-10 w-full md:w-1/2 max-w-2xl space-y-10">
-          <h1
-              className="
+      <div className="relative z-10 w-full md:w-1/2 max-w-2xl space-y-10">
+        <h1
+          className="
             text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-tight
             text-transparent bg-clip-text
             bg-gradient-to-r from-insta-pink via-insta-purple to-insta-blue
@@ -87,10 +89,10 @@ export default function Hero() {
             drop-shadow-[0_0_20px_rgba(214,41,118,0.6)]  /* pink glow shadow */
             leading-[1.1]
           "
-          >
-            Launch your course store in{' '}
-            <span
-                className="
+        >
+          Launch your course store in{" "}
+          <span
+            className="
               pulsing-underline                   /* pulsing neon underline */
               text-transparent bg-clip-text
               bg-gradient-to-r from-insta-yellow via-insta-orange to-insta-pink
@@ -99,24 +101,24 @@ export default function Hero() {
               transition-all duration-300
               cursor-pointer
             "
-            >
+          >
             4 minutes
-          </span>{' '}
-            — no code.
-          </h1>
+          </span>{" "}
+          — no code.
+        </h1>
 
-          <p
-              className="
+        <p
+          className="
             text-lg md:text-xl font-medium
             text-gray-100/90
             tracking-wide leading-relaxed
             transform transition-transform duration-500
             hover:scale-105                     /* slight pop on hover */
           "
-          >
-            Create{' '}
-            <span
-                className="
+        >
+          Create{" "}
+          <span
+            className="
               text-transparent bg-clip-text
               bg-gradient-to-r from-insta-orange via-insta-pink to-insta-purple
               animate-text-gradient          /* shimmer link text too */
@@ -125,20 +127,18 @@ export default function Hero() {
               hover:text-white
               hover:underline
             "
-            >
+          >
             gram.link/yourname
-          </span>{' '}
-            today.
-          </p>
+          </span>{" "}
+          today.
+        </p>
 
-          <div className="flex flex-col sm:flex-row items-center sm:items-start space-y-4 sm:space-y-0 sm:space-x-6">
-            <Button
-                size="lg"
-                aria-label="Start your free GramCourses store now in under 4 minutes"
-                onClick={() =>
-                    document.getElementById('wizard')?.classList.remove('hidden')
-                }
-                className="
+        <div className="flex flex-col sm:flex-row items-center sm:items-start space-y-4 sm:space-y-0 sm:space-x-6">
+          <Button
+            size="lg"
+            aria-label="Start your free GramCourses store now in under 4 minutes"
+            onClick={() => navigate("/wizard")}
+            className="
               bg-gradient-to-r from-insta-pink via-insta-purple to-insta-blue
               hover:from-insta-yellow hover:to-insta-orange
               shadow-insta-glow                /* multicolor drop shadow */
@@ -148,45 +148,45 @@ export default function Hero() {
               transform hover:scale-105          /* pop on hover */
               focus:outline-none focus:ring-6 focus:ring-insta-yellow/50
             "
-            >
-              Start Free Store
-            </Button>
+          >
+            Start Free Store
+          </Button>
 
-            <button
-                className="
+          <button
+            className="
               text-insta-yellow font-semibold underline
               px-4 py-2 rounded-lg
               hover:text-insta-pink hover:bg-insta-blue/20
               transition-all duration-300
               focus:outline-none focus:ring-4 focus:ring-insta-pink/40
             "
-                onClick={() => alert('demo modal')}
-            >
-              60‐sec demo →
-            </button>
-          </div>
+            onClick={() => navigate("/demo")}
+          >
+            60‐sec demo →
+          </button>
+        </div>
 
-          <div className="mt-6 space-y-2">
-            <LiveCounter className="text-insta-blue font-semibold text-lg" />
-            <p
-                className="
+        <div className="mt-6 space-y-2">
+          <LiveCounter className="text-insta-blue font-semibold text-lg" />
+          <p
+            className="
               text-sm text-gray-200/80
               tracking-wide
               animate-glow-pulse              /* ticker gently pulses */
             "
-            >
-              {ticker}
-            </p>
-          </div>
+          >
+            {ticker}
+          </p>
         </div>
+      </div>
 
-        {/** ──────────────────────────────────────────────────
+      {/** ──────────────────────────────────────────────────
          PHONE MOCKUP (z-10)
          ─────────────────────────────────────────────────── */}
-        <div className="relative z-10 w-full md:w-1/2 mt-12 md:mt-0 flex justify-center">
-          {/* Phone Shell */}
-          <div
-              className="
+      <div className="relative z-10 w-full md:w-1/2 mt-12 md:mt-0 flex justify-center">
+        {/* Phone Shell */}
+        <div
+          className="
             phone-mockup                       /* sci-fi phone shell */
             border-4 border-insta-purple/60
             rounded-[2rem]
@@ -198,21 +198,21 @@ export default function Hero() {
             hover:shadow-[0_0_60px_rgba(214,41,118,0.7),0_0_100px_rgba(79,91,213,0.5)]
             w-72 h-[400px]
           "
-          >
-            {/* Animated “Screen” Gradient */}
-            <div
-                className="
+        >
+          {/* Animated “Screen” Gradient */}
+          <div
+            className="
               absolute inset-0
               bg-gradient-to-r from-insta-yellow via-insta-orange to-insta-pink
               bg-[length:200%_200%]
               animate-insta-spectrum         /* cycles full Insta spectrum */
             "
-            />
-          </div>
+          />
+        </div>
 
-          {/* Floating Neon Sparks (–z-10, no blur) */}
-          <div
-              className="
+        {/* Floating Neon Sparks (–z-10, no blur) */}
+        <div
+          className="
             absolute -right-8 top-1/3
             w-12 h-12 rounded-full
             bg-gradient-to-tr from-insta-pink to-insta-purple
@@ -220,9 +220,9 @@ export default function Hero() {
             animate-floatY
             -z-10
           "
-          />
-          <div
-              className="
+        />
+        <div
+          className="
             absolute -bottom-6 right-1/4
             w-20 h-20 rounded-full
             bg-gradient-to-br from-insta-orange to-insta-blue
@@ -230,8 +230,8 @@ export default function Hero() {
             animate-floatX
             -z-10
           "
-          />
-        </div>
-      </section>
-  )
+        />
+      </div>
+    </section>
+  );
 }

--- a/src/components/LoadingDots.tsx
+++ b/src/components/LoadingDots.tsx
@@ -1,0 +1,9 @@
+export function LoadingDots() {
+  return (
+    <span className="inline-flex space-x-1">
+      <span className="w-1.5 h-1.5 bg-gray-300 rounded-full animate-pulse" />
+      <span className="w-1.5 h-1.5 bg-gray-300 rounded-full animate-pulse delay-150" />
+      <span className="w-1.5 h-1.5 bg-gray-300 rounded-full animate-pulse delay-300" />
+    </span>
+  );
+}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  currentStep: number;
+  total: number;
+}
+
+export function ProgressBar({ currentStep, total }: Props) {
+  const pct = (currentStep / total) * 100;
+  return (
+    <div className="w-full h-2 bg-dark2 rounded-full overflow-hidden">
+      <div
+        className="h-full bg-gradient-to-r from-primary via-secondary to-accent transition-width duration-300"
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}

--- a/src/components/modals/AIDemoModal.tsx
+++ b/src/components/modals/AIDemoModal.tsx
@@ -1,0 +1,21 @@
+import { useNavigate } from "react-router-dom";
+import { Modal } from "../ui/Modal";
+
+export default function AIDemoModal() {
+  const navigate = useNavigate();
+  const handleClose = () => navigate(-1);
+
+  return (
+    <Modal open onClose={handleClose}>
+      <div className="relative w-full">
+        <button
+          className="absolute -top-2 -right-2 text-white bg-dark2 rounded-full px-2"
+          onClick={handleClose}
+        >
+          ✕
+        </button>
+        <video className="w-full" src="/demo.mp4" controls autoPlay />
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/wizard/AIMarketingStep.tsx
+++ b/src/features/wizard/AIMarketingStep.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { setMarketing } from "./wizardSlice";
+import { useGenerateMarketingMutation } from "./aiAgent";
+import { Button } from "../../components/ui/Button";
+import { LoadingDots } from "../../components/LoadingDots";
+import type { RootState } from "../../store";
+
+interface Props {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export function AIMarketingStep({ onNext, onBack }: Props) {
+  const dispatch = useDispatch();
+  const basics = useSelector((s: RootState) => s.wizard.basics);
+  const pricing = useSelector((s: RootState) => s.wizard.pricing);
+  const [generate, { data, isLoading }] = useGenerateMarketingMutation();
+
+  useEffect(() => {
+    if (basics && pricing) {
+      generate({ basics, pricing });
+    }
+  }, [basics, pricing, generate]);
+
+  useEffect(() => {
+    if (data) {
+      dispatch(setMarketing(data));
+    }
+  }, [data, dispatch]);
+
+  return (
+    <div className="space-y-4">
+      {isLoading && (
+        <div className="text-center py-10">
+          <LoadingDots />
+        </div>
+      )}
+      {data && (
+        <div className="space-y-4">
+          <div>
+            <h3 className="font-semibold mb-1">Captions</h3>
+            <ul className="list-disc list-inside text-sm space-y-1">
+              {data.captions.map((c, i) => (
+                <li key={i}>{c}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-semibold mb-1">Hashtags</h3>
+            <p className="text-sm">{data.hashtags.join(" ")}</p>
+          </div>
+        </div>
+      )}
+      <div className="flex justify-between pt-4">
+        <Button onClick={onBack} variant="solid">
+          Back
+        </Button>
+        <Button onClick={onNext} disabled={!data}>
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/wizard/AIPricingStep.tsx
+++ b/src/features/wizard/AIPricingStep.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { setPricing } from "./wizardSlice";
+import { useGeneratePricingMutation } from "./aiAgent";
+import { Button } from "../../components/ui/Button";
+import { LoadingDots } from "../../components/LoadingDots";
+import type { RootState } from "../../store";
+
+interface Props {
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export function AIPricingStep({ onNext, onBack }: Props) {
+  const dispatch = useDispatch();
+  const basics = useSelector((s: RootState) => s.wizard.basics);
+  const [generatePricing, { data, isLoading }] = useGeneratePricingMutation();
+
+  useEffect(() => {
+    if (basics) {
+      generatePricing(basics);
+    }
+  }, [basics, generatePricing]);
+
+  useEffect(() => {
+    if (data) {
+      dispatch(setPricing(data));
+    }
+  }, [data, dispatch]);
+
+  return (
+    <div className="space-y-4">
+      {isLoading && (
+        <div className="text-center py-10">
+          <LoadingDots />
+        </div>
+      )}
+      {data && (
+        <ul className="space-y-2">
+          {data.tiers.map((t) => (
+            <li key={t.label} className="bg-dark2 rounded-md p-2">
+              {t.label}: ${t.price}
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="flex justify-between pt-4">
+        <Button onClick={onBack} variant="solid">
+          Back
+        </Button>
+        <Button onClick={onNext} disabled={!data}>
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/wizard/BusinessInfoStep.tsx
+++ b/src/features/wizard/BusinessInfoStep.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { useDispatch } from "react-redux";
+import { setBasics } from "./wizardSlice";
+import { FieldGroup } from "../../components/FieldGroup";
+import { Button } from "../../components/ui/Button";
+
+interface Props {
+  onNext: () => void;
+}
+
+export function BusinessInfoStep({ onNext }: Props) {
+  const dispatch = useDispatch();
+  const [niche, setNiche] = useState("");
+  const [productType, setProductType] = useState("");
+  const [targetPriceRange, setTargetPriceRange] = useState("");
+
+  const handleNext = () => {
+    dispatch(setBasics({ niche, productType, targetPriceRange }));
+    onNext();
+  };
+
+  return (
+    <div className="space-y-4">
+      <FieldGroup label="Your niche">
+        <input
+          className="w-full rounded-md bg-dark2 p-2"
+          value={niche}
+          onChange={(e) => setNiche(e.target.value)}
+        />
+      </FieldGroup>
+      <FieldGroup label="Product type">
+        <input
+          className="w-full rounded-md bg-dark2 p-2"
+          value={productType}
+          onChange={(e) => setProductType(e.target.value)}
+        />
+      </FieldGroup>
+      <FieldGroup label="Target price range">
+        <input
+          className="w-full rounded-md bg-dark2 p-2"
+          value={targetPriceRange}
+          onChange={(e) => setTargetPriceRange(e.target.value)}
+        />
+      </FieldGroup>
+      <div className="flex justify-end pt-4">
+        <Button onClick={handleNext}>Next</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/wizard/ReviewPublishStep.tsx
+++ b/src/features/wizard/ReviewPublishStep.tsx
@@ -1,0 +1,27 @@
+import { useSelector } from "react-redux";
+import { Button } from "../../components/ui/Button";
+import type { RootState } from "../../store";
+
+interface Props {
+  onBack: () => void;
+}
+
+export function ReviewPublishStep({ onBack }: Props) {
+  const { basics, pricing, marketing } = useSelector(
+    (s: RootState) => s.wizard,
+  );
+
+  return (
+    <div className="space-y-4">
+      <pre className="bg-dark2 p-4 rounded-md text-sm whitespace-pre-wrap">
+        {JSON.stringify({ basics, pricing, marketing }, null, 2)}
+      </pre>
+      <div className="flex justify-between pt-4">
+        <Button onClick={onBack} variant="solid">
+          Back
+        </Button>
+        <Button>Publish</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/wizard/WizardLayout.tsx
+++ b/src/features/wizard/WizardLayout.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import { ProgressBar } from "../../components/ProgressBar";
+import { BusinessInfoStep } from "./BusinessInfoStep";
+import { AIPricingStep } from "./AIPricingStep";
+import { AIMarketingStep } from "./AIMarketingStep";
+import { ReviewPublishStep } from "./ReviewPublishStep";
+
+const steps = [
+  BusinessInfoStep,
+  AIPricingStep,
+  AIMarketingStep,
+  ReviewPublishStep,
+];
+
+export default function WizardLayout() {
+  const [step, setStep] = useState(0);
+  const Step = steps[step];
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6 bg-dark1">
+      <div className="w-full max-w-lg space-y-6">
+        <ProgressBar currentStep={step + 1} total={steps.length} />
+        <Step
+          onNext={() => setStep(Math.min(step + 1, steps.length - 1))}
+          onBack={() => setStep(Math.max(step - 1, 0))}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/wizard/__tests__/wizardSlice.test.ts
+++ b/src/features/wizard/__tests__/wizardSlice.test.ts
@@ -1,0 +1,23 @@
+import { wizardSlice, setBasics, setPricing, reset } from "../wizardSlice";
+
+const reducer = wizardSlice.reducer;
+
+describe("wizardSlice", () => {
+  it("sets basics", () => {
+    const state = reducer(
+      undefined,
+      setBasics({
+        niche: "fitness",
+        productType: "video",
+        targetPriceRange: "$50",
+      }),
+    );
+    expect(state.basics?.niche).toBe("fitness");
+  });
+
+  it("resets state", () => {
+    const initial = reducer(undefined, setPricing({ tiers: [] }));
+    const cleared = reducer(initial, reset());
+    expect(cleared.pricing).toBeNull();
+  });
+});

--- a/src/features/wizard/aiAgent.ts
+++ b/src/features/wizard/aiAgent.ts
@@ -1,0 +1,31 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import type { Basics, PricingData, MarketingData } from "./types";
+
+const baseUrl = import.meta.env.VITE_OPENAI_API_URL as string;
+
+export const wizardApi = createApi({
+  reducerPath: "wizardApi",
+  baseQuery: fetchBaseQuery({ baseUrl }),
+  endpoints: (builder) => ({
+    generatePricing: builder.mutation<PricingData, Basics>({
+      query: (basics) => ({
+        url: "/api/ai/pricing",
+        method: "POST",
+        body: basics,
+      }),
+    }),
+    generateMarketing: builder.mutation<
+      MarketingData,
+      { basics: Basics; pricing: PricingData }
+    >({
+      query: ({ basics, pricing }) => ({
+        url: "/api/ai/marketing",
+        method: "POST",
+        body: { basics, pricing },
+      }),
+    }),
+  }),
+});
+
+export const { useGeneratePricingMutation, useGenerateMarketingMutation } =
+  wizardApi;

--- a/src/features/wizard/types.ts
+++ b/src/features/wizard/types.ts
@@ -1,0 +1,14 @@
+export interface Basics {
+  niche: string;
+  productType: string;
+  targetPriceRange: string;
+}
+
+export interface PricingData {
+  tiers: Array<{ label: string; price: number }>;
+}
+
+export interface MarketingData {
+  captions: string[];
+  hashtags: string[];
+}

--- a/src/features/wizard/wizardSlice.ts
+++ b/src/features/wizard/wizardSlice.ts
@@ -1,0 +1,41 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import type { Basics, PricingData, MarketingData } from "./types";
+
+export interface WizardState {
+  basics: Basics | null;
+  pricing: PricingData | null;
+  marketing: MarketingData | null;
+  status: "idle" | "loading" | "published";
+}
+
+const initialState: WizardState = {
+  basics: null,
+  pricing: null,
+  marketing: null,
+  status: "idle",
+};
+
+export const wizardSlice = createSlice({
+  name: "wizard",
+  initialState,
+  reducers: {
+    setBasics(state, action: PayloadAction<Basics>) {
+      state.basics = action.payload;
+    },
+    setPricing(state, action: PayloadAction<PricingData>) {
+      state.pricing = action.payload;
+    },
+    setMarketing(state, action: PayloadAction<MarketingData>) {
+      state.marketing = action.payload;
+    },
+    setStatus(state, action: PayloadAction<WizardState["status"]>) {
+      state.status = action.payload;
+    },
+    reset() {
+      return initialState;
+    },
+  },
+});
+
+export const { setBasics, setPricing, setMarketing, setStatus, reset } =
+  wizardSlice.actions;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
-import { App } from './App';
-import './index.css';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import { App } from "./App";
+import { store } from "./store";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
+  </React.StrictMode>,
 );

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,15 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { wizardSlice } from "./features/wizard/wizardSlice";
+import { wizardApi } from "./features/wizard/aiAgent";
+
+export const store = configureStore({
+  reducer: {
+    wizard: wizardSlice.reducer,
+    [wizardApi.reducerPath]: wizardApi.reducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(wizardApi.middleware),
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## Summary
- add environment variable instructions in README
- set up Redux Toolkit and Prettier
- implement wizard slice, API hooks and steps
- add Wizard layout, progress bar and helper components
- add demo modal and new routes
- connect Redux Provider
- include unit tests for wizardSlice

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68434d48b9cc8333880d9e0a0d5277ab