### PR TITLE
Improve wizard navigation with route params

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ export function App() {
         <Suspense fallback={<div className="p-8">Loading...</div>}>
           <Routes>
             <Route path="/" element={<Landing />} />
-            <Route path="/wizard" element={<WizardLayout />} />
+            <Route path="/wizard/:stepIndex?" element={<WizardLayout />} />
             <Route path="/demo" element={<AIDemoModal />} />
           </Routes>
         </Suspense>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -137,7 +137,7 @@ export default function Hero() {
           <Button
             size="lg"
             aria-label="Start your free GramCourses store now in under 4 minutes"
-            onClick={() => navigate("/wizard")}
+            onClick={() => navigate("/wizard/0")}
             className="
               bg-gradient-to-r from-insta-pink via-insta-purple to-insta-blue
               hover:from-insta-yellow hover:to-insta-orange

--- a/src/features/wizard/index.tsx
+++ b/src/features/wizard/index.tsx
@@ -1,5 +1,7 @@
-import { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
 import { ProgressBar } from "../../components/ProgressBar";
+import { reset } from "./wizardSlice";
 import { BusinessInfoStep } from "./BusinessInfoStep";
 import { AIPricingStep } from "./AIPricingStep";
 import { AIMarketingStep } from "./AIMarketingStep";
@@ -20,13 +22,35 @@ const fadeSlide = {
 };
 
 export default function WizardLayout() {
-  const [step, setStep] = useState(0);
-  const Step = steps[step];
+  const { stepIndex } = useParams();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const step = Number(stepIndex) || 0;
+  const Step = steps[step] ?? steps[0];
+
+  const handleNext = () =>
+    navigate(`/wizard/${Math.min(step + 1, steps.length - 1)}`);
+  const handleBack = () => {
+    if (step === 0) navigate("/");
+    else navigate(`/wizard/${step - 1}`);
+  };
+  const handleExit = () => {
+    dispatch(reset());
+    navigate("/");
+  };
 
   return (
     <div className="min-h-screen flex items-center justify-center p-6 bg-dark1">
       <div className="w-full max-w-lg space-y-6">
-        <ProgressBar currentStep={step + 1} total={steps.length} />
+        <div className="flex justify-between items-center">
+          <button
+            className="text-sm text-gray-400 hover:underline"
+            onClick={handleExit}
+          >
+            Exit Wizard
+          </button>
+          <ProgressBar currentStep={step + 1} total={steps.length} />
+        </div>
         <AnimatePresence mode="wait">
           <motion.div
             key={step}
@@ -35,10 +59,7 @@ export default function WizardLayout() {
             animate="animate"
             exit="exit"
           >
-            <Step
-              onNext={() => setStep(Math.min(step + 1, steps.length - 1))}
-              onBack={() => setStep(Math.max(step - 1, 0))}
-            />
+            <Step onNext={handleNext} onBack={handleBack} />
           </motion.div>
         </AnimatePresence>
       </div>


### PR DESCRIPTION
## Summary
- let wizard route accept `/wizard/:stepIndex?`
- update Hero buttons to point to `/wizard/0`
- drive wizard progress from URL params
- provide Exit Wizard control and navigation helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435db48a60833385084d098692cdfe