### PR TITLE
Improve wizard navigation with route params

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ npm run test:e2e  # Cypress smoke tests
 Set the following environment variables before running the wizard:
 
 ```bash
-VITE_OPENAI_API_URL=<your-ai-endpoint>
-VITE_STRIPE_PK=<your-stripe-publishable-key>
+VITE_OPENAI_API_URL=https://api.openai.example.com
+VITE_STRIPE_PK=pk_test_XXXXXXXXXXXXXXXX
 ```
 
 These keys power the pricing and marketing steps during the AI onboarding flow.
+Click **Start Free Store** on the home page to begin. At any time you can click
+“Exit Wizard” in the top‑right corner to clear your progress and return home.
 
 Run the dev server with:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-icons": "^4.12.0",
         "react-redux": "^9.2.0",
         "react-router-dom": "^6.30.1",
+        "recharts": "^2.15.3",
         "smoothscroll-polyfill": "^0.4.4"
       },
       "devDependencies": {
@@ -572,7 +573,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3333,6 +3333,69 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -5049,7 +5112,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cypress": {
@@ -5150,6 +5212,127 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -5207,6 +5390,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -5314,6 +5503,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
@@ -5791,6 +5990,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
@@ -5905,6 +6110,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -6757,6 +6971,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arrayish": {
@@ -8302,7 +8525,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -8895,7 +9117,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -9031,6 +9252,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lottie-react": {
@@ -9385,7 +9618,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10049,6 +10281,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
@@ -10234,6 +10483,37 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -10256,6 +10536,44 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
+      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -11182,6 +11500,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
@@ -11630,6 +11954,28 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-icons": "^4.12.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.30.1",
+    "recharts": "^2.15.3",
     "smoothscroll-polyfill": "^0.4.4"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ export function App() {
         <Suspense fallback={<div className="p-8">Loading...</div>}>
           <Routes>
             <Route path="/" element={<Landing />} />
-            <Route path="/wizard" element={<WizardLayout />} />
+            <Route path="/wizard/:stepIndex?" element={<WizardLayout />} />
             <Route path="/demo" element={<AIDemoModal />} />
           </Routes>
         </Suspense>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -137,7 +137,7 @@ export default function Hero() {
           <Button
             size="lg"
             aria-label="Start your free GramCourses store now in under 4 minutes"
-            onClick={() => navigate("/wizard")}
+            onClick={() => navigate("/wizard/0")}
             className="
               bg-gradient-to-r from-insta-pink via-insta-purple to-insta-blue
               hover:from-insta-yellow hover:to-insta-orange

--- a/src/features/wizard/AIMarketingStep.tsx
+++ b/src/features/wizard/AIMarketingStep.tsx
@@ -18,6 +18,7 @@ export function AIMarketingStep({ onNext, onBack }: Props) {
   const dispatch = useDispatch();
   const basics = useSelector((s: RootState) => s.wizard.basics);
   const pricing = useSelector((s: RootState) => s.wizard.pricing);
+  const marketing = useSelector((s: RootState) => s.wizard.marketing);
   const [generate, { data, isLoading }] = useGenerateMarketingMutation();
   const [captions, setCaptions] = useState<string[]>([]);
   const [hashtags, setHashtags] = useState<string[]>([]);
@@ -27,10 +28,14 @@ export function AIMarketingStep({ onNext, onBack }: Props) {
   useWizardGuard(2);
 
   useEffect(() => {
-    if (basics && pricing) {
+    if (marketing) {
+      setCaptions(marketing.captions);
+      setHashtags(marketing.hashtags);
+      setTimes(marketing.bestTimes || []);
+    } else if (basics && pricing) {
       generate({ basics, pricing });
     }
-  }, [basics, pricing, generate]);
+  }, [marketing, basics, pricing, generate]);
 
   useEffect(() => {
     if (data) {

--- a/src/features/wizard/AIPricingStep.tsx
+++ b/src/features/wizard/AIPricingStep.tsx
@@ -16,6 +16,7 @@ interface Props {
 export function AIPricingStep({ onNext, onBack }: Props) {
   const dispatch = useDispatch();
   const basics = useSelector((s: RootState) => s.wizard.basics);
+  const pricing = useSelector((s: RootState) => s.wizard.pricing);
   const [generatePricing, { data, isLoading }] = useGeneratePricingMutation();
   const [tiers, setTiers] = useState<Array<{ label: string; price: number }>>(
     [],
@@ -23,10 +24,12 @@ export function AIPricingStep({ onNext, onBack }: Props) {
   useWizardGuard(1);
 
   useEffect(() => {
-    if (basics) {
+    if (pricing) {
+      setTiers(pricing.tiers);
+    } else if (basics) {
       generatePricing(basics);
     }
-  }, [basics, generatePricing]);
+  }, [pricing, basics, generatePricing]);
 
   useEffect(() => {
     if (data) {

--- a/src/features/wizard/BusinessInfoStep.tsx
+++ b/src/features/wizard/BusinessInfoStep.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
-import { useDispatch } from "react-redux";
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { setBasics } from "./wizardSlice";
+import type { RootState } from "../../store";
 import { FieldGroup } from "../../components/FieldGroup";
 import { Button } from "../../components/ui/Button";
 import { motion } from "framer-motion";
@@ -11,9 +12,18 @@ interface Props {
 
 export function BusinessInfoStep({ onNext }: Props) {
   const dispatch = useDispatch();
+  const basics = useSelector((s: RootState) => s.wizard.basics);
   const [niche, setNiche] = useState("");
   const [productType, setProductType] = useState("");
   const [targetPriceRange, setTargetPriceRange] = useState("");
+
+  useEffect(() => {
+    if (basics) {
+      setNiche(basics.niche);
+      setProductType(basics.productType);
+      setTargetPriceRange(basics.targetPriceRange);
+    }
+  }, [basics]);
 
   const handleNext = () => {
     dispatch(setBasics({ niche, productType, targetPriceRange }));

--- a/src/features/wizard/__tests__/useWizardGuard.test.tsx
+++ b/src/features/wizard/__tests__/useWizardGuard.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { wizardSlice } from "../wizardSlice";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { useWizardGuard } from "../useWizardGuard";
+
+function Guarded({ step }: { step: number }) {
+  useWizardGuard(step);
+  return <div>step{step}</div>;
+}
+
+function setup(initialEntries: string[], step: number) {
+  const store = configureStore({ reducer: { wizard: wizardSlice.reducer } });
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route path="/wizard/:stepIndex" element={<Guarded step={step} />} />
+          <Route path="/wizard/0" element={<div>step0</div>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>
+  );
+}
+
+test("redirects to step 0 when basics missing", async () => {
+  setup(["/wizard/1"], 1);
+  await waitFor(() => expect(screen.getByText("step0")).toBeInTheDocument());
+});
+
+test("stays on step when data present", async () => {
+  const store = configureStore({ reducer: { wizard: wizardSlice.reducer } });
+  store.dispatch(
+    wizardSlice.actions.setBasics({ niche: "x", productType: "v", targetPriceRange: "$" })
+  );
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/wizard/1"]}>
+        <Routes>
+          <Route path="/wizard/:stepIndex" element={<Guarded step={1} />} />
+          <Route path="/wizard/0" element={<div>step0</div>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(screen.getByText("step1")).toBeInTheDocument();
+});

--- a/src/features/wizard/__tests__/wizardSlice.test.ts
+++ b/src/features/wizard/__tests__/wizardSlice.test.ts
@@ -1,4 +1,10 @@
-import { wizardSlice, setBasics, setPricing, reset } from "../wizardSlice";
+import {
+  wizardSlice,
+  setBasics,
+  setPricing,
+  setMarketing,
+  reset,
+} from "../wizardSlice";
 
 const reducer = wizardSlice.reducer;
 
@@ -13,6 +19,22 @@ describe("wizardSlice", () => {
       }),
     );
     expect(state.basics?.niche).toBe("fitness");
+  });
+
+  it("sets pricing", () => {
+    const state = reducer(
+      undefined,
+      setPricing({ tiers: [{ label: "pro", price: 10 }] }),
+    );
+    expect(state.pricing?.tiers[0].label).toBe("pro");
+  });
+
+  it("sets marketing", () => {
+    const state = reducer(
+      undefined,
+      setMarketing({ captions: ["hi"], hashtags: ["#x"] }),
+    );
+    expect(state.marketing?.captions[0]).toBe("hi");
   });
 
   it("resets state", () => {

--- a/src/features/wizard/index.tsx
+++ b/src/features/wizard/index.tsx
@@ -1,5 +1,7 @@
-import { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
 import { ProgressBar } from "../../components/ProgressBar";
+import { reset } from "./wizardSlice";
 import { BusinessInfoStep } from "./BusinessInfoStep";
 import { AIPricingStep } from "./AIPricingStep";
 import { AIMarketingStep } from "./AIMarketingStep";
@@ -20,13 +22,35 @@ const fadeSlide = {
 };
 
 export default function WizardLayout() {
-  const [step, setStep] = useState(0);
-  const Step = steps[step];
+  const { stepIndex } = useParams();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const step = Number(stepIndex) || 0;
+  const Step = steps[step] ?? steps[0];
+
+  const handleNext = () =>
+    navigate(`/wizard/${Math.min(step + 1, steps.length - 1)}`);
+  const handleBack = () => {
+    if (step === 0) navigate("/");
+    else navigate(`/wizard/${step - 1}`);
+  };
+  const handleExit = () => {
+    dispatch(reset());
+    navigate("/");
+  };
 
   return (
     <div className="min-h-screen flex items-center justify-center p-6 bg-dark1">
       <div className="w-full max-w-lg space-y-6">
-        <ProgressBar currentStep={step + 1} total={steps.length} />
+        <div className="flex justify-between items-center">
+          <button
+            className="text-sm text-gray-400 hover:underline"
+            onClick={handleExit}
+          >
+            Exit Wizard
+          </button>
+          <ProgressBar currentStep={step + 1} total={steps.length} />
+        </div>
         <AnimatePresence mode="wait">
           <motion.div
             key={step}
@@ -35,10 +59,7 @@ export default function WizardLayout() {
             animate="animate"
             exit="exit"
           >
-            <Step
-              onNext={() => setStep(Math.min(step + 1, steps.length - 1))}
-              onBack={() => setStep(Math.max(step - 1, 0))}
-            />
+            <Step onNext={handleNext} onBack={handleBack} />
           </motion.div>
         </AnimatePresence>
       </div>

--- a/src/features/wizard/useWizardGuard.ts
+++ b/src/features/wizard/useWizardGuard.ts
@@ -10,8 +10,8 @@ export function useWizardGuard(step: number) {
   );
 
   useEffect(() => {
-    if (step > 0 && !basics) navigate("/wizard");
-    else if (step > 1 && !pricing) navigate("/wizard");
-    else if (step > 2 && !marketing) navigate("/wizard");
+    if (step >= 1 && !basics) navigate("/wizard/0");
+    else if (step >= 2 && !pricing) navigate("/wizard/1");
+    else if (step >= 3 && !marketing) navigate("/wizard/2");
   }, [step, basics, pricing, marketing, navigate]);
 }


### PR DESCRIPTION
## Summary
- let wizard route accept `/wizard/:stepIndex?`
- update Hero buttons to point to `/wizard/0`
- drive wizard progress from URL params
- provide Exit Wizard control and navigation helpers
- persist wizard form values via Redux and enforce guards
- add unit tests for reducers and guarding logic
- document environment variables for AI wizard and Stripe
- include recharts so build passes

## Testing
- `npm run lint`
- `npm run build`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68435db48a60833385084d098692cdfe