### PR TITLE
Improve wizard navigation & tests

### DIFF
--- a/src/features/wizard/__tests__/BusinessInfoStep.test.tsx
+++ b/src/features/wizard/__tests__/BusinessInfoStep.test.tsx
@@ -31,3 +31,22 @@ test("dispatches basics on next", () => {
   expect(state.basics?.niche).toBe("ai");
   expect(onNext).toHaveBeenCalled();
 });
+
+test("prefills form from state", () => {
+  const store = configureStore({ reducer: { wizard: wizardSlice.reducer } });
+  store.dispatch(
+    wizardSlice.actions.setBasics({
+      niche: "fitness",
+      productType: "video",
+      targetPriceRange: "$0-49",
+    }),
+  );
+  render(
+    <Provider store={store}>
+      <BusinessInfoStep onNext={jest.fn()} />
+    </Provider>,
+  );
+  expect(screen.getByLabelText(/your niche/i)).toHaveValue("fitness");
+  expect(screen.getByLabelText(/product type/i)).toHaveValue("video");
+  expect(screen.getByLabelText(/target price range/i)).toHaveValue("$0-49");
+});

--- a/src/features/wizard/index.tsx
+++ b/src/features/wizard/index.tsx
@@ -1,7 +1,9 @@
 import { useParams, useNavigate } from "react-router-dom";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { useEffect } from "react";
 import { ProgressBar } from "../../components/ProgressBar";
 import { reset } from "./wizardSlice";
+import type { RootState } from "../../store";
 import { BusinessInfoStep } from "./BusinessInfoStep";
 import { AIPricingStep } from "./AIPricingStep";
 import { AIMarketingStep } from "./AIMarketingStep";
@@ -25,14 +27,30 @@ export default function WizardLayout() {
   const { stepIndex } = useParams();
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const step = Number(stepIndex) || 0;
-  const Step = steps[step] ?? steps[0];
+  const { basics, pricing, marketing } = useSelector(
+    (s: RootState) => s.wizard,
+  );
+
+  let maxCompleted = 0;
+  if (basics) maxCompleted = 1;
+  if (pricing) maxCompleted = 2;
+  if (marketing) maxCompleted = 3;
+
+  const urlStep = Number(stepIndex) || 0;
+  const currentStep = Math.min(urlStep, maxCompleted);
+  const Step = steps[currentStep] ?? steps[0];
+
+  useEffect(() => {
+    if (urlStep !== currentStep) {
+      navigate(`/wizard/${currentStep}`, { replace: true });
+    }
+  }, [urlStep, currentStep, navigate]);
 
   const handleNext = () =>
-    navigate(`/wizard/${Math.min(step + 1, steps.length - 1)}`);
+    navigate(`/wizard/${Math.min(currentStep + 1, steps.length - 1)}`);
   const handleBack = () => {
-    if (step === 0) navigate("/");
-    else navigate(`/wizard/${step - 1}`);
+    if (currentStep === 0) navigate("/");
+    else navigate(`/wizard/${currentStep - 1}`);
   };
   const handleExit = () => {
     dispatch(reset());
@@ -49,11 +67,11 @@ export default function WizardLayout() {
           >
             Exit Wizard
           </button>
-          <ProgressBar currentStep={step + 1} total={steps.length} />
+          <ProgressBar currentStep={currentStep + 1} total={steps.length} />
         </div>
         <AnimatePresence mode="wait">
           <motion.div
-            key={step}
+            key={currentStep}
             variants={fadeSlide}
             initial="initial"
             animate="animate"


### PR DESCRIPTION
## Summary
- track wizard progress from Redux state and URL
- ensure navigation redirects to the first valid step
- update progress bar usage
- add regression test verifying form fields prefill from state

## Testing
- `npm test --silent`
- `npm run build --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843885fc6148333a919916f4de39aec