### PR TITLE
Update UI content for AI Business Coach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CourseGram
+# AI Business Coach
 
 Rebooted landing experience built with React, Vite and Tailwind CSS. UI components live under `src/components` and page routes in `src/pages`. Global layout and navigation sit in `src/layout`.
 
@@ -25,7 +25,7 @@ PORT=3001
 ```
 
 These keys power the pricing and marketing steps during the AI onboarding flow.
-Click **Start Free Store** on the home page to begin. At any time you can click
+Click **Launch with AI Now** on the home page to begin. At any time you can click
 “Exit Wizard” in the top‑right corner to clear your progress and return home.
 
 Run the dev server with:

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CourseGram</title>
+    <title>AI Business Coach</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -5,13 +5,13 @@ import { Button } from "./ui/Button";
 import { LiveCounter } from "./LiveCounter";
 
 export default function Hero() {
-  const [ticker, setTicker] = useState("@coachmike just earned $3,482");
+  const [ticker, setTicker] = useState("AI Coach just helped launch a $3.5k campaign");
   const navigate = useNavigate();
   useEffect(() => {
     const data = [
-      "@coachmike just earned $3,482",
-      "@creatorsara just earned $1,208",
-      "@buildtim just earned $542",
+      "AI Coach just helped launch a $3.5k campaign",
+      "AI Coach just unlocked $1.2k in sales",
+      "AI Coach just optimized a $500 drop",
     ];
     let i = 0;
     const id = setInterval(() => {
@@ -90,7 +90,7 @@ export default function Hero() {
             leading-[1.1]
           "
         >
-          Launch your course store in{" "}
+          Launch your business with AI in{" "}
           <span
             className="
               pulsing-underline                   /* pulsing neon underline */
@@ -128,7 +128,7 @@ export default function Hero() {
               hover:underline
             "
           >
-            gram.link/yourname
+            smart.link/yourname
           </span>{" "}
           today.
         </p>
@@ -136,7 +136,7 @@ export default function Hero() {
         <div className="flex flex-col sm:flex-row items-center sm:items-start space-y-4 sm:space-y-0 sm:space-x-6">
           <Button
             size="lg"
-            aria-label="Start your free GramCourses store now in under 4 minutes"
+            aria-label="Launch your AI-driven business now in under 4 minutes"
             onClick={() => navigate("/wizard/0")}
             className="
               bg-gradient-to-r from-insta-pink via-insta-purple to-insta-blue
@@ -149,7 +149,7 @@ export default function Hero() {
               focus:outline-none focus:ring-6 focus:ring-insta-yellow/50
             "
           >
-            Start Free Store
+            Launch with AI Now
           </Button>
 
           <button

--- a/src/components/LiveCounter.tsx
+++ b/src/components/LiveCounter.tsx
@@ -21,7 +21,7 @@ export function LiveCounter({ className = '' }: { className?: string }) {
         ${className}
       `}
       >
-      ${formatted} earned by creators
+      ${formatted} earned by founders
     </span>
   )
 }

--- a/src/components/WizardDrawer.tsx
+++ b/src/components/WizardDrawer.tsx
@@ -43,7 +43,7 @@ export default function WizardDrawer() {
             drop-shadow-2xl                             /* NEW: neon glow under heading */
           "
                 >
-                    Start in 4 Minutes
+                Launch with AI in 4 Minutes
                 </h2>
 
                 <p
@@ -53,7 +53,7 @@ export default function WizardDrawer() {
             hover:text-white transition-colors duration-300 /* NEW: text brightens on hover */
           "
                 >
-                    Pick a template to begin.
+                    Let AI set up your launch.
                 </p>
 
                 <Button

--- a/src/data/creators.ts
+++ b/src/data/creators.ts
@@ -9,32 +9,32 @@ export const creators: Creator[] = [
   {
     name: 'Jordan P.',
     handle: 'jordanp',
-    quote: 'Made $1.2k in 3 days.',
+    quote: 'AI boosted my launch to $1.2k in 3 days.',
     badge: 'Top Vouch',
   },
   {
     name: 'Alex M.',
     handle: 'alexm',
-    quote: 'Sold out on day one!',
+    quote: 'AI marketing sold out day one!',
   },
   {
     name: 'Rachel K.',
     handle: 'rachelk',
-    quote: 'My followers love it.',
+    quote: 'My followers love the AI tips.',
   },
   {
     name: 'Lena T.',
     handle: 'lenat',
-    quote: 'Tripled my revenue.',
+    quote: 'AI tripled my revenue.',
   },
   {
     name: 'Tom B.',
     handle: 'tomb',
-    quote: 'Seamless payments!',
+    quote: 'AI handled payments seamlessly.',
   },
   {
     name: 'Sara Q.',
     handle: 'saraq',
-    quote: 'Launch was instant.',
+    quote: 'AI made launch instant.',
   },
 ];

--- a/src/data/features.tsx
+++ b/src/data/features.tsx
@@ -17,32 +17,32 @@ export interface Feature {
 export const features: Feature[] = [
   {
     icon: <RocketLaunchIcon className="w-8 h-8 text-primary" />,
-    title: 'Fast Setup',
-    text: 'Setup in minutes.',
+    title: 'AI Quickstart',
+    text: 'Launch in minutes with automated setup.',
   },
   {
     icon: <BanknotesIcon className="w-8 h-8 text-primary" />,
-    title: 'Payments',
-    text: 'Stripe & Apple Pay out-of-box.',
+    title: 'Instant Payments',
+    text: 'AI auto-connects Stripe & Apple Pay.',
   },
   {
     icon: <ChartBarIcon className="w-8 h-8 text-primary" />,
-    title: 'Analytics',
-    text: 'Know what converts.',
+    title: 'AI Insights & Forecasts',
+    text: 'Smart predictions on what sells.',
   },
   {
     icon: <LinkIcon className="w-8 h-8 text-primary" />,
-    title: 'gram.link',
-    text: 'Shareable vanity URL.',
+    title: 'Smart Link',
+    text: 'Smart Product Link for your AI-driven business.',
   },
   {
     icon: <SwatchIcon className="w-8 h-8 text-primary" />,
-    title: 'Customization',
-    text: 'Match your brand.',
+    title: 'AI Branding',
+    text: 'Match your style instantly.',
   },
   {
     icon: <LifebuoyIcon className="w-8 h-8 text-primary" />,
-    title: 'Support',
-    text: '24 / 7 creator chat.',
+    title: '24/7 Founder Support',
+    text: 'AI + human chat around the clock.',
   },
 ];

--- a/src/data/tiers.ts
+++ b/src/data/tiers.ts
@@ -9,17 +9,17 @@ export const tiers: Tier[] = [
   {
     name: 'Basic',
     price: '$9/mo',
-    features: ['Unlimited courses', 'Vanity URL'],
+    features: ['Unlimited AI launches', 'Smart Product Link'],
   },
   {
     name: 'Pro',
     price: '$39/mo',
-    features: ['Analytics', 'Email capture', 'Priority support'],
+    features: ['AI Insights & Forecasts', 'AI email capture', 'Priority support'],
     highlight: true,
   },
   {
     name: 'Premium',
     price: '$79/mo',
-    features: ['Everything Pro', 'Dedicated manager', 'API'],
+    features: ['Everything Pro', 'Dedicated AI strategist', 'API access'],
   },
 ];

--- a/src/index.css
+++ b/src/index.css
@@ -185,7 +185,7 @@ html {
   animation: underlinePulse 2s infinite ease-in-out;
 }
 
-/* Underline Link in Hero (e.g., “gram.link/yourname”) */
+/* Underline Link in Hero (e.g., “smart.link/yourname”) */
 .hero-link {
   @apply text-primary font-medium relative inline-block;
   background-image: linear-gradient(

--- a/src/layout/Navbar.tsx
+++ b/src/layout/Navbar.tsx
@@ -10,7 +10,7 @@ export function Navbar() {
   return (
     <header className="fixed top-0 left-0 w-full bg-dark1/80 backdrop-blur-sm z-50 shadow-md">
       <div className="max-w-7xl mx-auto flex items-center justify-between px-6 h-20">
-        <Link to="/" className="text-2xl font-bold text-white">GramCourses</Link>
+        <Link to="/" className="text-2xl font-bold text-white">AI Business Coach</Link>
         <nav className="hidden md:flex flex-1 justify-center space-x-6">
           <SmoothLink href="#home" className="nav-link" aria-label="Home">
             Home
@@ -21,8 +21,8 @@ export function Navbar() {
           <SmoothLink href="#pricing" className="nav-link" aria-label="Pricing">
             Pricing
           </SmoothLink>
-          <SmoothLink href="#creators" className="nav-link" aria-label="Creators">
-            Creators
+          <SmoothLink href="#creators" className="nav-link" aria-label="Founders">
+            Founders
           </SmoothLink>
         </nav>
         <Button
@@ -30,7 +30,7 @@ export function Navbar() {
           className="hidden md:block"
           onClick={() => document.getElementById('wizard')?.classList.remove('hidden')}
         >
-          Launch in 4 min
+          Launch with AI
         </Button>
         <button
           className="md:hidden p-2 text-white focus:outline-none focus:ring-4 focus:ring-primary/50"
@@ -52,8 +52,8 @@ export function Navbar() {
           <SmoothLink href="#pricing" className="block nav-link" aria-label="Pricing" onClick={() => setOpen(false)}>
             Pricing
           </SmoothLink>
-          <SmoothLink href="#creators" className="block nav-link" aria-label="Creators" onClick={() => setOpen(false)}>
-            Creators
+          <SmoothLink href="#creators" className="block nav-link" aria-label="Founders" onClick={() => setOpen(false)}>
+            Founders
           </SmoothLink>
           <Button
             size="sm"
@@ -63,7 +63,7 @@ export function Navbar() {
               setOpen(false);
             }}
           >
-            Launch in 4 min
+            Launch with AI
           </Button>
         </div>
       )}

--- a/src/pages/Creators.tsx
+++ b/src/pages/Creators.tsx
@@ -42,7 +42,7 @@ export default function Creators() {
           text-center mb-12
         "
             >
-                Success Stories
+                AI Founder Wins
             </h2>
 
             {/** ─────────────────────────────────────────────────
@@ -240,7 +240,7 @@ export default function Creators() {
               "
                             onClick={() => alert('view store')}
                         >
-                            View Store →
+                            View Launch →
                         </Button>
                     </div>
                 )}

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -46,7 +46,7 @@ export default function Pricing() {
           text-center mb-12 z-10
         "
             >
-                Pricing &amp; Plans
+                Plans for AI-Powered Growth
             </h2>
 
             {/* Toggle Buttons */}
@@ -102,7 +102,7 @@ export default function Pricing() {
         "
                 onClick={() => document.getElementById('wizard')?.classList.remove('hidden')}
             >
-                Pick Pro Now
+                Pick AI Pro Now
             </Button>
 
             {/* Pricing Cards Grid */}


### PR DESCRIPTION
## Summary
- update site title and README for new brand
- rewrite hero section with AI-focused copy
- rename navigation and CTA text
- adjust features, tiers, and success stories to emphasize AI
- tweak pricing and creator pages to match branding

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: @eslint/js missing)*
- `npm run test:e2e` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844386ec0b08333954403f73997d578