### PR TITLE
Implement AI simulation lifecycle with tests

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, ReactNode } from 'react';
+import { Button } from './ui/Button';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  handleRestart = () => {
+    window.location.assign('/wizard/0');
+  };
+
+  handleSupport = () => {
+    window.location.href = 'mailto:support@example.com';
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-8 space-y-4" role="alert">
+          <h2 className="text-xl font-semibold">Something went wrong.</h2>
+          <div className="space-x-2">
+            <Button aria-label="Restart Wizard" onClick={this.handleRestart}>
+              Restart Wizard
+            </Button>
+            <Button
+              aria-label="Contact Support"
+              variant="solid"
+              onClick={this.handleSupport}
+            >
+              Contact Support
+            </Button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/__tests__/TimerBar.test.tsx
+++ b/src/components/__tests__/TimerBar.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import { TimerBar } from '../TimerBar';
+
+test('renders null with invalid props', () => {
+  const { container } = render(<TimerBar />);
+  expect(container.firstChild).toBeNull();
+});
+
+test('updates width on step change', () => {
+  const { container, rerender } = render(<TimerBar currentStep={1} total={4} />);
+  const bar = container.querySelector('.h-full') as HTMLElement;
+  expect(bar.style.width).toBe('25%');
+  rerender(<TimerBar currentStep={2} total={4} />);
+  expect(bar.style.width).toBe('50%');
+});

--- a/src/features/simulator/AIWrapper.tsx
+++ b/src/features/simulator/AIWrapper.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid } from 'recharts';
+import { useNextSimStepMutation } from './simApi';
+import { addAdvice, clearSession, setStatus } from './simSlice';
+import { Button } from '../../components/ui/Button';
+import type { RootState } from '../../store';
+import { useNetworkStatus } from '../../hooks/useNetworkStatus';
+
+export function AIWrapper() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { simId, weekPlan, forecast, advice, status } = useSelector(
+    (s: RootState) => s.simulation,
+  );
+  const [nextStep] = useNextSimStepMutation();
+  const [polling, setPolling] = useState(status === 'running');
+  const online = useNetworkStatus();
+
+  useEffect(() => {
+    if (!simId || !polling) return;
+    const id = setInterval(async () => {
+      try {
+        const res = await nextStep({
+          simId,
+          metrics: { sales: 0, traffic: 0, cvr: 0 },
+        }).unwrap();
+        dispatch(
+          addAdvice({
+            weekPlan: res.updatedPlan,
+            forecast: res.forecast,
+            advice: res.advice,
+          }),
+        );
+      } catch {
+        setPolling(false);
+      }
+    }, 5000);
+    return () => clearInterval(id);
+  }, [simId, polling, nextStep, dispatch]);
+
+  const pause = () => {
+    dispatch(setStatus(status === 'running' ? 'paused' : 'running'));
+    setPolling((p) => !p);
+  };
+
+  const skip = async () => {
+    if (!simId) return;
+    try {
+      const res = await nextStep({
+        simId,
+        metrics: { sales: 0, traffic: 0, cvr: 0 },
+      }).unwrap();
+      dispatch(
+        addAdvice({ weekPlan: res.updatedPlan, forecast: res.forecast, advice: res.advice }),
+      );
+    } catch {
+      /* noop */
+    }
+  };
+
+  const restart = () => {
+    dispatch(clearSession());
+    navigate('/wizard/0');
+  };
+
+  if (!simId) {
+    return <div className="p-8">No active simulation</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-4" aria-live="polite">
+      {!online && (
+        <div className="text-red-500">Offline — reconnect to continue.</div>
+      )}
+      {weekPlan && (
+        <ul className="list-disc pl-5" aria-label="Weekly Plan">
+          {weekPlan.tasks.map((t, i) => (
+            <li key={i}>{t}</li>
+          ))}
+        </ul>
+      )}
+      {forecast && (
+        <LineChart width={320} height={200} data={forecast.months} className="mx-auto">
+          <CartesianGrid stroke="#ccc" />
+          <XAxis dataKey="month" />
+          <YAxis />
+          <Line type="monotone" dataKey="revenue" stroke="#8884d8" />
+        </LineChart>
+      )}
+      {advice.map((a, i) => (
+        <p key={i} className="bg-dark2 p-2 rounded" aria-label={`Advice ${i + 1}`}>{a}</p>
+      ))}
+      <div className="space-x-2">
+        <Button aria-label="Pause Simulation" onClick={pause} disabled={!online}>
+          {polling ? 'Pause' : 'Resume'}
+        </Button>
+        <Button aria-label="Skip Week" onClick={skip} disabled={!online || !polling}>
+          Skip Week
+        </Button>
+        <Button aria-label="Restart Simulation" onClick={restart} variant="solid">
+          Restart Simulation
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/simulator/simSlice.ts
+++ b/src/features/simulator/simSlice.ts
@@ -6,6 +6,7 @@ interface SimState {
   weekPlan: WeekPlan | null;
   forecast: Forecast | null;
   advice: string[];
+  status: 'idle' | 'running' | 'paused';
 }
 
 const initialState: SimState = {
@@ -13,6 +14,7 @@ const initialState: SimState = {
   weekPlan: null,
   forecast: null,
   advice: [],
+  status: 'idle',
 };
 
 export const simSlice = createSlice({
@@ -23,11 +25,15 @@ export const simSlice = createSlice({
       state.simId = action.payload.simId;
       state.weekPlan = action.payload.weekPlan;
       state.forecast = action.payload.forecast;
+      state.status = 'running';
     },
     addAdvice(state, action: PayloadAction<{ weekPlan: WeekPlan; forecast: Forecast; advice: string }>) {
       state.weekPlan = action.payload.weekPlan;
       state.forecast = action.payload.forecast;
       state.advice.push(action.payload.advice);
+    },
+    setStatus(state, action: PayloadAction<SimState['status']>) {
+      state.status = action.payload;
     },
     clearSession() {
       return initialState;
@@ -35,5 +41,5 @@ export const simSlice = createSlice({
   },
 });
 
-export const { setSession, addAdvice, clearSession } = simSlice.actions;
+export const { setSession, addAdvice, setStatus, clearSession } = simSlice.actions;
 export default simSlice.reducer;

--- a/src/features/wizard/WizardFlow.tsx
+++ b/src/features/wizard/WizardFlow.tsx
@@ -20,6 +20,7 @@ import {
 import { useStartSimMutation } from "../simulator/simApi";
 import { setSession } from "../simulator/simSlice";
 import type { RootState } from "../../store";
+import { useNetworkStatus } from "../../hooks/useNetworkStatus";
 
 const fadeSlide = {
   initial: { opacity: 0, x: -20 },
@@ -44,6 +45,7 @@ export default function WizardFlow() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [startSim] = useStartSimMutation();
+  const online = useNetworkStatus();
 
   useEffect(() => {
     setIdx(Number(stepIndex) || 0);
@@ -110,6 +112,11 @@ export default function WizardFlow() {
           <Button onClick={handleNext}>Retry</Button>
         </div>
       )}
+      {!online && (
+        <div className="absolute inset-0 bg-black/70 flex items-center justify-center z-40 text-white">
+          Offline — reconnect to continue.
+        </div>
+      )}
       <div className="w-full max-w-lg space-y-6">
         <div className="flex justify-between items-center">
           <button className="text-sm text-gray-400 hover:underline" onClick={handleExit}>
@@ -128,10 +135,10 @@ export default function WizardFlow() {
           </motion.div>
         </AnimatePresence>
         <div className="flex justify-between pt-4">
-          <Button onClick={handleBack} variant="solid">
+          <Button onClick={handleBack} variant="solid" disabled={!online}>
             {idx === 0 ? "Exit" : "Back"}
           </Button>
-          <Button onClick={handleNext} disabled={!canNext}>
+          <Button onClick={handleNext} disabled={!canNext || !online}>
             {idx === steps.length - 1 ? "Start" : "Next"}
           </Button>
         </div>

--- a/src/features/wizard/__tests__/BusinessInfoStep.test.tsx
+++ b/src/features/wizard/__tests__/BusinessInfoStep.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { wizardSlice } from "../wizardSlice";
@@ -29,6 +29,16 @@ test("validate and get data", () => {
   });
   expect(ref.current?.isValid()).toBe(true);
   expect(ref.current?.getData().niche).toBe("ai");
+});
+
+test("shows errors when fields missing", () => {
+  const { ref } = renderWithStore();
+  let valid = true;
+  act(() => {
+    valid = ref.current?.isValid() ?? true;
+  });
+  expect(valid).toBe(false);
+  expect(screen.getAllByText(/required/i).length).toBeGreaterThan(0);
 });
 
 test("prefills form from state", () => {

--- a/src/features/wizard/index.tsx
+++ b/src/features/wizard/index.tsx
@@ -1,1 +1,10 @@
-export { default } from './WizardFlow';
+import WizardFlow from './WizardFlow';
+import { ErrorBoundary } from '../../components/ErrorBoundary';
+
+export default function WizardLayout() {
+  return (
+    <ErrorBoundary>
+      <WizardFlow />
+    </ErrorBoundary>
+  );
+}

--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+export function useNetworkStatus(): boolean {
+  const [online, setOnline] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const check = async () => {
+      try {
+        const res = await fetch('/ping');
+        if (!cancelled) setOnline(res.ok);
+      } catch {
+        if (!cancelled) setOnline(false);
+      }
+    };
+    check();
+    const id = setInterval(check, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  useEffect(() => {
+    const goOnline = () => setOnline(true);
+    const goOffline = () => setOnline(false);
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, []);
+
+  return online;
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,33 +1,5 @@
-import { useSelector, useDispatch } from 'react-redux';
-import { useState } from 'react';
-import { useNextSimStepMutation } from '../features/simulator/simApi';
-import { addAdvice } from '../features/simulator/simSlice';
-import type { RootState } from '../store';
-import { Button } from '../components/ui/Button';
+import { AIWrapper } from '../features/simulator/AIWrapper';
 
 export default function Dashboard() {
-  const dispatch = useDispatch();
-  const { simId, weekPlan, forecast, advice } = useSelector((s: RootState) => s.simulation);
-  const [metrics, setMetrics] = useState({ sales: 0, traffic: 0, cvr: 0 });
-  const [nextSimStep, { isLoading }] = useNextSimStepMutation();
-
-  if (!simId) return <div className="p-8">No active simulation</div>;
-
-  const submit = async () => {
-    const res = await nextSimStep({ simId, metrics }).unwrap();
-    dispatch(addAdvice({ weekPlan: res.updatedPlan, forecast: res.forecast, advice: res.advice }));
-  };
-
-  return (
-    <div className="p-8 space-y-4">
-      <h1 className="text-2xl font-bold">Dashboard</h1>
-      <pre className="bg-dark2 p-4 rounded text-sm">{JSON.stringify({ weekPlan, forecast, advice }, null, 2)}</pre>
-      <div className="space-x-2">
-        <input className="bg-dark2 p-2" type="number" value={metrics.sales} onChange={e => setMetrics({ ...metrics, sales: Number(e.target.value) })} placeholder="sales" />
-        <input className="bg-dark2 p-2" type="number" value={metrics.traffic} onChange={e => setMetrics({ ...metrics, traffic: Number(e.target.value) })} placeholder="traffic" />
-        <input className="bg-dark2 p-2" type="number" value={metrics.cvr} onChange={e => setMetrics({ ...metrics, cvr: Number(e.target.value) })} placeholder="cvr" />
-        <Button onClick={submit} disabled={isLoading}>Send</Button>
-      </div>
-    </div>
-  );
+  return <AIWrapper />;
 }


### PR DESCRIPTION
## Summary
- add AIWrapper component to drive simulation lifecycle
- create ErrorBoundary component
- detect offline status with useNetworkStatus hook
- persist simulation status in simSlice
- improve WizardFlow with network awareness
- update Dashboard to render AIWrapper
- add TimerBar tests and strengthen BusinessInfoStep tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68444ef62a7883339423998740eea40a