### PR TITLE
Add simulation runner integration

### DIFF
--- a/cypress/e2e/simulation.cy.ts
+++ b/cypress/e2e/simulation.cy.ts
@@ -1,0 +1,13 @@
+describe('Wizard simulation flow', () => {
+  it('runs through wizard and launches simulation', () => {
+    cy.visit('/wizard/0');
+    cy.get('input[aria-label="Your niche"]').type('ai');
+    cy.get('input[aria-label="Product type"]').type('video');
+    cy.get('select[aria-label="Target price range"]').select('$');
+    cy.contains('Next').click();
+    cy.contains('Next').click();
+    cy.contains('Next').click();
+    cy.contains('Launch').click();
+    cy.contains('Launching your AI Simulation').should('be.visible');
+  });
+});

--- a/src/features/simulator/__tests__/SimulationRunner.test.tsx
+++ b/src/features/simulator/__tests__/SimulationRunner.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, fireEvent, act, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import simulationReducer, { setSession } from '../simSlice';
+import { SimulationRunner } from '../SimulationRunner';
+
+const nextMock = jest.fn();
+const endMock = jest.fn();
+
+jest.mock('../simApi', () => ({
+  useNextSimStepMutation: () => [
+    (args: any) => ({ unwrap: () => nextMock(args) }),
+    { isLoading: false, error: null },
+  ],
+  useEndSimMutation: () => [
+    () => ({ unwrap: () => endMock() }),
+    {},
+  ],
+}));
+
+function setup() {
+  const store = configureStore({ reducer: { simulation: simulationReducer } });
+  store.dispatch(
+    setSession({ simId: 'abc', weekPlan: { tasks: [] }, forecast: { months: [] } })
+  );
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <SimulationRunner simId="abc" />
+      </MemoryRouter>
+    </Provider>
+  );
+  return { store };
+}
+
+test('advances week on button click', async () => {
+  nextMock.mockResolvedValue({
+    updatedPlan: { tasks: ['a'] },
+    forecast: { months: [] },
+    advice: 'ok',
+  });
+  setup();
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /next week/i }));
+  });
+  expect(nextMock).toHaveBeenCalled();
+});

--- a/src/features/simulator/simApi.ts
+++ b/src/features/simulator/simApi.ts
@@ -15,7 +15,16 @@ export const simApi = createApi({
     startSim: builder.mutation<StartResponse, { basics: Basics }>({
       query: (body) => ({ url: 'simulation/start', method: 'POST', body }),
     }),
-    nextSimStep: builder.mutation<{ updatedPlan: WeekPlan; forecast: Forecast; advice: string }, { simId: string; metrics: Metrics }>({
+    getSimStatus: builder.query<
+      { weekPlan: WeekPlan; forecast: Forecast; currentWeek: number; isComplete: boolean },
+      { simId: string }
+    >({
+      query: ({ simId }) => ({ url: `simulation/status/${simId}` }),
+    }),
+    nextSimStep: builder.mutation<
+      { updatedPlan: WeekPlan; forecast: Forecast; advice: string },
+      { simId: string; metrics: Metrics }
+    >({
       query: (body) => ({ url: 'simulation/next-step', method: 'POST', body }),
     }),
     endSim: builder.mutation<{ summary: string }, { simId: string }>({
@@ -24,4 +33,9 @@ export const simApi = createApi({
   }),
 });
 
-export const { useStartSimMutation, useNextSimStepMutation, useEndSimMutation } = simApi;
+export const {
+  useStartSimMutation,
+  useGetSimStatusQuery,
+  useNextSimStepMutation,
+  useEndSimMutation,
+} = simApi;

--- a/src/features/simulator/simSlice.ts
+++ b/src/features/simulator/simSlice.ts
@@ -3,17 +3,19 @@ import type { WeekPlan, Forecast } from '../../types/business';
 
 interface SimState {
   simId: string | null;
+  currentWeek: number;
   weekPlan: WeekPlan | null;
   forecast: Forecast | null;
-  advice: string[];
+  adviceHistory: string[];
   status: 'idle' | 'running' | 'paused';
 }
 
 const initialState: SimState = {
   simId: null,
+  currentWeek: 0,
   weekPlan: null,
   forecast: null,
-  advice: [],
+  adviceHistory: [],
   status: 'idle',
 };
 
@@ -21,16 +23,24 @@ export const simSlice = createSlice({
   name: 'simulation',
   initialState,
   reducers: {
-    setSession(state, action: PayloadAction<{ simId: string; weekPlan: WeekPlan; forecast: Forecast }>) {
+    setSession(
+      state,
+      action: PayloadAction<{ simId: string; weekPlan: WeekPlan; forecast: Forecast }>,
+    ) {
       state.simId = action.payload.simId;
+      state.currentWeek = 1;
       state.weekPlan = action.payload.weekPlan;
       state.forecast = action.payload.forecast;
       state.status = 'running';
     },
-    addAdvice(state, action: PayloadAction<{ weekPlan: WeekPlan; forecast: Forecast; advice: string }>) {
+    addAdvice(
+      state,
+      action: PayloadAction<{ weekPlan: WeekPlan; forecast: Forecast; advice: string }>,
+    ) {
+      state.currentWeek += 1;
       state.weekPlan = action.payload.weekPlan;
       state.forecast = action.payload.forecast;
-      state.advice.push(action.payload.advice);
+      state.adviceHistory.push(action.payload.advice);
     },
     setStatus(state, action: PayloadAction<SimState['status']>) {
       state.status = action.payload;
@@ -42,4 +52,9 @@ export const simSlice = createSlice({
 });
 
 export const { setSession, addAdvice, setStatus, clearSession } = simSlice.actions;
+
+// Selectors
+export const selectCurrentSession = (state: { simulation: SimState }) => state.simulation;
+export const selectSimulationWeek = (state: { simulation: SimState }) => state.simulation.currentWeek;
+
 export default simSlice.reducer;

--- a/src/features/wizard/ReviewPublishStep.tsx
+++ b/src/features/wizard/ReviewPublishStep.tsx
@@ -5,7 +5,6 @@ import {
   useState,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { LoadingDots } from '../../components/LoadingDots';
 import { Toast } from '../../components/ui/Toast';
@@ -35,13 +34,12 @@ export interface ReviewHandles {
 
 export const ReviewPublishStep = forwardRef<ReviewHandles>((_, ref) => {
   const dispatch = useDispatch();
-  const navigate = useNavigate();
   const data = useSelector((s: RootState) => s.wizard);
   const [startSim] = useStartSimMutation();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  const launch = async () => {
+  const launch = async (): Promise<string | undefined> => {
     if (!data.basics) return;
     try {
       setError('');
@@ -64,9 +62,10 @@ export const ReviewPublishStep = forwardRef<ReviewHandles>((_, ref) => {
         }),
       );
 
-      navigate(`/simulation/${res.simId}`);
+      return res.simId;
     } catch {
       setError('Failed to start simulation. Please try again.');
+      return undefined;
     } finally {
       setLoading(false);
     }

--- a/src/features/wizard/__tests__/ReviewPublishStep.test.tsx
+++ b/src/features/wizard/__tests__/ReviewPublishStep.test.tsx
@@ -7,13 +7,7 @@ import { wizardSlice } from '../wizardSlice';
 import simulationReducer from '../../simulator/simSlice';
 import { ReviewPublishStep, type ReviewHandles } from '../ReviewPublishStep';
 
-const navigateMock = jest.fn();
 const startMock = jest.fn();
-
-jest.mock('react-router-dom', () => {
-  const actual = jest.requireActual('react-router-dom');
-  return { ...actual, useNavigate: () => navigateMock };
-});
 
 jest.mock('../../simulator/simApi', () => ({
   useStartSimMutation: () => [ (args: any) => ({ unwrap: () => startMock(args) }) ],
@@ -44,12 +38,13 @@ test('launches simulation and dispatches session', async () => {
     forecast: { months: [] },
   });
   const { store, ref } = setup();
+  let returned: string | undefined;
   await act(async () => {
-    await ref.current?.launch();
+    returned = await ref.current!.launch();
   });
   expect(startMock).toHaveBeenCalled();
   expect(store.getState().simulation.simId).toBe('123');
-  expect(navigateMock).toHaveBeenCalledWith('/simulation/123');
+  expect(returned).toBe('123');
 });
 
 test('shows error on failure', async () => {


### PR DESCRIPTION
## Summary
- integrate sim API with status query
- persist session data in sim slice and add selectors
- rework SimulationRunner to accept props and manage state
- wire SimulationRunner into WizardFlow
- launch simulation from ReviewPublishStep without navigation
- basic unit tests and cypress flow for simulation

## Testing
- `npm test` *(fails: Type 'void' is not assignable to type 'string | undefined'.)*

------
https://chatgpt.com/codex/tasks/task_e_68446459220083339581b2300362a1cf