### PR TITLE
Fix pricing step by adding missing API routes

### DIFF
--- a/src/server/routes/ai.ts
+++ b/src/server/routes/ai.ts
@@ -1,9 +1,64 @@
 import { Router } from "express";
 import { AISession } from "../aiSession";
+import { chat } from "../openaiHelper";
+import type { Basics, PricingTier } from "../../types/business";
+
+interface PricingData {
+  tiers: PricingTier[];
+}
+
+interface MarketingData {
+  captions: string[];
+  hashtags: string[];
+  bestTimes?: Array<{ time: string; count: number }>;
+}
 
 const sessions = new Map<string, AISession>();
 
 const router = Router();
+
+// Generate AI pricing tiers
+router.post('/pricing', async (req, res) => {
+  try {
+    const basics: Basics = req.body;
+    const content = await chat([
+      {
+        role: 'system',
+        content:
+          'Generate product pricing tiers as JSON {"tiers":[{"label":"Basic","price":10}]}',
+      },
+      { role: 'user', content: JSON.stringify(basics) },
+    ]);
+    const parsed = JSON.parse(content) as PricingData;
+    res.json(parsed);
+  } catch (err) {
+    const e = err as Error & { message?: string };
+    res.status(502).json({ error: 'AI_ERROR', message: String(e.message || e) });
+  }
+});
+
+// Generate AI marketing plan
+router.post('/marketing', async (req, res) => {
+  try {
+    const { basics, pricing } = req.body as {
+      basics: Basics;
+      pricing: PricingData;
+    };
+    const content = await chat([
+      {
+        role: 'system',
+        content:
+          'Generate marketing captions, hashtags and best posting times as JSON',
+      },
+      { role: 'user', content: JSON.stringify({ basics, pricing }) },
+    ]);
+    const parsed = JSON.parse(content) as MarketingData;
+    res.json(parsed);
+  } catch (err) {
+    const e = err as Error & { message?: string };
+    res.status(502).json({ error: 'AI_ERROR', message: String(e.message || e) });
+  }
+});
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 router.post("/simulation/start", async (req: any, res: any) => {

--- a/src/server/tests/routes.test.ts
+++ b/src/server/tests/routes.test.ts
@@ -22,3 +22,19 @@ test('POST /api/simulation/start', async () => {
   expect(res.status).toBe(200);
   expect(res.body.simId).toBeDefined();
 });
+
+test('POST /api/pricing', async () => {
+  mockedChat.mockResolvedValue('{"tiers":[{"label":"Basic","price":10}]}');
+  const res = await request(app).post('/api/pricing').send({ niche: 'x', productType: 'y', targetPriceRange: '$' });
+  expect(res.status).toBe(200);
+  expect(res.body.tiers[0].label).toBe('Basic');
+});
+
+test('POST /api/marketing', async () => {
+  mockedChat.mockResolvedValue('{"captions":["hi"],"hashtags":["#x"],"bestTimes":[]}');
+  const res = await request(app)
+    .post('/api/marketing')
+    .send({ basics: { niche: 'x', productType: 'y', targetPriceRange: '$' }, pricing: { tiers: [] } });
+  expect(res.status).toBe(200);
+  expect(res.body.captions[0]).toBe('hi');
+});


### PR DESCRIPTION
## Summary
- implement `/api/pricing` and `/api/marketing` endpoints
- extend tests to cover the new routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68446de781a08333bed60b88d8a38299