### PR TITLE
Fix wizard flow validation

### DIFF
--- a/src/features/wizard/BusinessInfoStep.tsx
+++ b/src/features/wizard/BusinessInfoStep.tsx
@@ -25,7 +25,12 @@ const fade = {
   animate: { opacity: 1, x: 0 },
 };
 
-const BusinessInfoStep = forwardRef<BusinessInfoHandles>((_, ref) => {
+export interface BusinessInfoStepProps {
+  onChange?: (data: Basics) => void;
+}
+
+const BusinessInfoStep = forwardRef<BusinessInfoHandles, BusinessInfoStepProps>(
+  ({ onChange }, ref) => {
   const stored = useSelector((s: RootState) => s.wizard.basics);
 
   const [niche, setNiche] = useState("");
@@ -46,6 +51,11 @@ const BusinessInfoStep = forwardRef<BusinessInfoHandles>((_, ref) => {
       setTargetPriceRange(stored.targetPriceRange);
     }
   }, [stored]);
+
+  // notify parent on changes
+  useEffect(() => {
+    onChange?.({ niche, productType, targetPriceRange });
+  }, [niche, productType, targetPriceRange, onChange]);
 
   const validate = () => {
     const errs: Record<string, string> = {};

--- a/src/features/wizard/WizardFlow.tsx
+++ b/src/features/wizard/WizardFlow.tsx
@@ -21,7 +21,7 @@ import {
   reset as resetWizard,
 } from "./wizardSlice";
 import type { RootState } from "../../store";
-// import type { Basics } from "./types";                  ← removed unused import
+import type { Basics } from "./types";
 import { useNetworkStatus } from "../../hooks/useNetworkStatus";
 
 const fadeSlide = {
@@ -41,6 +41,11 @@ export default function WizardFlow() {
   const [idx, setIdx]                   = useState(Number(stepIndex) || 0);
   const [runningSimId, setRunningSimId] = useState<string | null>(null);
   const online                          = useNetworkStatus();
+  const [infoData, setInfoData]         = useState<Basics>({
+    niche: "",
+    productType: "",
+    targetPriceRange: "",
+  });
 
   // keep idx in sync with the URL
   useEffect(() => {
@@ -62,10 +67,7 @@ export default function WizardFlow() {
   // “Next” is enabled only if the current step is valid and we’re not already launching
   const canNext =
     idx === 0
-      ? (() => {
-          const data = infoRef.current?.getData();
-          return !!data?.niche && !!data?.productType && !!data?.targetPriceRange;
-        })()
+      ? !!infoData.niche && !!infoData.productType && !!infoData.targetPriceRange
       : idx === 1
         ? pricingRef.current?.isValid() ?? false
         : idx === 2
@@ -154,7 +156,7 @@ export default function WizardFlow() {
               {runningSimId ? (
                   <SimulationRunner simId={runningSimId} />
               ) : idx === 0 ? (
-                  <BusinessInfoStep ref={infoRef} />
+                  <BusinessInfoStep ref={infoRef} onChange={setInfoData} />
               ) : idx === 1 ? (
                   <AIPricingStep ref={pricingRef} />
               ) : idx === 2 ? (

--- a/src/features/wizard/__tests__/BusinessInfoStep.test.tsx
+++ b/src/features/wizard/__tests__/BusinessInfoStep.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { wizardSlice } from '../wizardSlice';
@@ -10,7 +10,7 @@ function setup() {
   const ref = React.createRef<BusinessInfoHandles>();
   render(
     <Provider store={store}>
-      <BusinessInfoStep ref={ref} />
+      <BusinessInfoStep ref={ref} onChange={() => {}} />
     </Provider>
   );
   return { store, ref };
@@ -21,13 +21,20 @@ test('isValid and getData return values when fields complete', () => {
   fireEvent.change(screen.getByLabelText(/your niche/i), { target: { value: 'ai' } });
   fireEvent.change(screen.getByLabelText(/product type/i), { target: { value: 'video' } });
   fireEvent.change(screen.getByLabelText(/target price range/i), { target: { value: '$0-49' } });
-
-  expect(ref.current!.isValid()).toBe(true);
+  let valid = false;
+  act(() => {
+    valid = ref.current!.isValid();
+  });
+  expect(valid).toBe(true);
   expect(ref.current!.getData()).toEqual({ niche: 'ai', productType: 'video', targetPriceRange: '$0-49' });
 });
 
 test('isValid shows errors when fields missing', () => {
   const { ref } = setup();
-  expect(ref.current!.isValid()).toBe(false);
+  let valid = true;
+  act(() => {
+    valid = ref.current!.isValid();
+  });
+  expect(valid).toBe(false);
   expect(screen.getAllByText(/required/i).length).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- notify WizardFlow when business info changes
- enable WizardFlow Next button using wizard info
- update BusinessInfoStep tests to wrap act

## Testing
- `npx jest src/features/wizard/__tests__/BusinessInfoStep.test.tsx`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844b4611ddc833387df9a392b314e1a