### PR TITLE
Fix wizard pricing step fallback

### DIFF
--- a/src/features/wizard/AIPricingStep.tsx
+++ b/src/features/wizard/AIPricingStep.tsx
@@ -7,6 +7,7 @@ import {
 import { useSelector } from "react-redux";
 import type { RootState } from "../../store";
 import { useGeneratePricingMutation } from "./aiAgent";
+import { tiers as fallbackTiers } from "../../data/tiers";
 import { LoadingDots } from "../../components/LoadingDots";
 import { Toast } from "../../components/ui/Toast";
 import { Button } from "../../components/ui/Button";
@@ -47,6 +48,18 @@ export const AIPricingStep = forwardRef<PricingHandles>((_, ref) => {
   useEffect(() => {
     if (error) setErrMsg('Failed to load pricing data.');
   }, [error]);
+
+  // fallback to local pricing tiers when API fails
+  useEffect(() => {
+    if (error && tiers.length === 0) {
+      setTiers(
+        fallbackTiers.map((t) => ({
+          label: t.name,
+          price: Number(String(t.price).replace(/[^0-9.]/g, "")),
+        }))
+      );
+    }
+  }, [error, tiers.length]);
 
   const validate = () => {
     const invalid = tiers.length === 0 || tiers.some((t) => !t.label || !t.price);

--- a/src/features/wizard/BusinessInfoStep.tsx
+++ b/src/features/wizard/BusinessInfoStep.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
   useEffect,
   useRef,
+  useCallback,
 } from "react";
 import { useSelector } from "react-redux";
 import type { RootState } from "../../store";
@@ -25,7 +26,12 @@ const fade = {
   animate: { opacity: 1, x: 0 },
 };
 
-const BusinessInfoStep = forwardRef<BusinessInfoHandles>((_, ref) => {
+export interface BusinessInfoStepProps {
+  onChange?: (data: Basics) => void;
+}
+
+const BusinessInfoStep = forwardRef<BusinessInfoHandles, BusinessInfoStepProps>(
+  ({ onChange }, ref) => {
   const stored = useSelector((s: RootState) => s.wizard.basics);
 
   const [niche, setNiche] = useState("");
@@ -47,7 +53,12 @@ const BusinessInfoStep = forwardRef<BusinessInfoHandles>((_, ref) => {
     }
   }, [stored]);
 
-  const validate = () => {
+  // notify parent on changes
+  useEffect(() => {
+    onChange?.({ niche, productType, targetPriceRange });
+  }, [niche, productType, targetPriceRange, onChange]);
+
+  const validate = useCallback(() => {
     const errs: Record<string, string> = {};
     if (!niche) errs.niche = "Required";
     if (!productType) errs.productType = "Required";
@@ -73,7 +84,7 @@ const BusinessInfoStep = forwardRef<BusinessInfoHandles>((_, ref) => {
     }
 
     return true;
-  };
+  }, [niche, productType, targetPriceRange]);
 
   // expose our two methods to the wizard container
   useImperativeHandle(

--- a/src/features/wizard/WizardFlow.tsx
+++ b/src/features/wizard/WizardFlow.tsx
@@ -21,7 +21,7 @@ import {
   reset as resetWizard,
 } from "./wizardSlice";
 import type { RootState } from "../../store";
-// import type { Basics } from "./types";                  ← removed unused import
+import type { Basics } from "./types";
 import { useNetworkStatus } from "../../hooks/useNetworkStatus";
 
 const fadeSlide = {
@@ -41,6 +41,11 @@ export default function WizardFlow() {
   const [idx, setIdx]                   = useState(Number(stepIndex) || 0);
   const [runningSimId, setRunningSimId] = useState<string | null>(null);
   const online                          = useNetworkStatus();
+  const [infoData, setInfoData]         = useState<Basics>({
+    niche: "",
+    productType: "",
+    targetPriceRange: "",
+  });
 
   // keep idx in sync with the URL
   useEffect(() => {
@@ -62,10 +67,7 @@ export default function WizardFlow() {
   // “Next” is enabled only if the current step is valid and we’re not already launching
   const canNext =
     idx === 0
-      ? (() => {
-          const data = infoRef.current?.getData();
-          return !!data?.niche && !!data?.productType && !!data?.targetPriceRange;
-        })()
+      ? !!infoData.niche && !!infoData.productType && !!infoData.targetPriceRange
       : idx === 1
         ? pricingRef.current?.isValid() ?? false
         : idx === 2
@@ -154,7 +156,7 @@ export default function WizardFlow() {
               {runningSimId ? (
                   <SimulationRunner simId={runningSimId} />
               ) : idx === 0 ? (
-                  <BusinessInfoStep ref={infoRef} />
+                  <BusinessInfoStep ref={infoRef} onChange={setInfoData} />
               ) : idx === 1 ? (
                   <AIPricingStep ref={pricingRef} />
               ) : idx === 2 ? (

--- a/src/features/wizard/__tests__/AIPricingStep.test.tsx
+++ b/src/features/wizard/__tests__/AIPricingStep.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { wizardSlice } from '../wizardSlice';
+import { AIPricingStep, type PricingHandles } from '../AIPricingStep';
+
+const generateMock = jest.fn();
+
+jest.mock('../aiAgent', () => ({
+  useGeneratePricingMutation: () => [generateMock, { data: undefined, error: new Error('fail'), isLoading: false }]
+}));
+
+function setup() {
+  const store = configureStore({ reducer: { wizard: wizardSlice.reducer } });
+  // preload basics so step guard allows render
+  store.dispatch(wizardSlice.actions.setBasics({ niche: 'ai', productType: 'vid', targetPriceRange: '$' }));
+  const ref = React.createRef<PricingHandles>();
+  render(
+    <Provider store={store}>
+      <AIPricingStep ref={ref} />
+    </Provider>
+  );
+  return { ref };
+}
+
+test('uses fallback tiers on API error', () => {
+  const { ref } = setup();
+  expect(screen.getByDisplayValue('Basic')).toBeInTheDocument();
+  expect(ref.current?.getData().tiers.length).toBeGreaterThan(0);
+});

--- a/src/features/wizard/__tests__/BusinessInfoStep.test.tsx
+++ b/src/features/wizard/__tests__/BusinessInfoStep.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { wizardSlice } from '../wizardSlice';
@@ -10,7 +10,7 @@ function setup() {
   const ref = React.createRef<BusinessInfoHandles>();
   render(
     <Provider store={store}>
-      <BusinessInfoStep ref={ref} />
+      <BusinessInfoStep ref={ref} onChange={() => {}} />
     </Provider>
   );
   return { store, ref };
@@ -21,13 +21,20 @@ test('isValid and getData return values when fields complete', () => {
   fireEvent.change(screen.getByLabelText(/your niche/i), { target: { value: 'ai' } });
   fireEvent.change(screen.getByLabelText(/product type/i), { target: { value: 'video' } });
   fireEvent.change(screen.getByLabelText(/target price range/i), { target: { value: '$0-49' } });
-
-  expect(ref.current!.isValid()).toBe(true);
+  let valid = false;
+  act(() => {
+    valid = ref.current!.isValid();
+  });
+  expect(valid).toBe(true);
   expect(ref.current!.getData()).toEqual({ niche: 'ai', productType: 'video', targetPriceRange: '$0-49' });
 });
 
 test('isValid shows errors when fields missing', () => {
   const { ref } = setup();
-  expect(ref.current!.isValid()).toBe(false);
+  let valid = true;
+  act(() => {
+    valid = ref.current!.isValid();
+  });
+  expect(valid).toBe(false);
   expect(screen.getAllByText(/required/i).length).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- use local tiers as fallback when pricing API fails
- add a test covering pricing fallback logic

## Testing
- `npx jest --runInBand --ci`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844b4611ddc833387df9a392b314e1a